### PR TITLE
Fix placeholder text in 2 doc files

### DIFF
--- a/scripts/prepare-docs.mjs
+++ b/scripts/prepare-docs.mjs
@@ -322,10 +322,19 @@ async function fixKnownDocsIssues(docsRoot) {
     docsRoot,
     "building-features/how-to-use-different-files-for-client-and-server-rendering.md",
     (content) =>
-      content.replace(
-        /^## How to use different versions of a file for client and server rendering/m,
-        "# How to use different versions of a file for client and server rendering"
-      )
+      content
+        .replace(
+          /^## How to use different versions of a file for client and server rendering/m,
+          "# How to use different versions of a file for client and server rendering"
+        )
+        .replace(/\.\.\. \/\/ blah blah/g, "// ... other aliases")
+  );
+
+  await rewriteDoc(docsRoot, "building-features/images.md", (content) =>
+    content.replace(
+      "1. leading slash necessary on the\n   a. Option name for the file-loader and url-loader (todo reference)\n   b. Option publicPath for the output (todo reference)",
+      "A leading slash is necessary on the `name` option for file-loader/url-loader and the `publicPath` option for output."
+    )
   );
 
   await rewriteDoc(docsRoot, "migrating/migrating-from-react-rails.md", (content) =>


### PR DESCRIPTION
## Summary
- Replace `... // blah blah` placeholder comments with `// ... other aliases` in the webpack config examples in `how-to-use-different-files-for-client-and-server-rendering.md`
- Replace incomplete `(todo reference)` notes with a proper description in `images.md`
- Both fixes are applied during the `prepare:docs` step via `fixKnownDocsIssues()`

## Test plan
- [x] Run `npm run prepare:docs` — succeeds
- [x] Run `npm run audit:docs` — no placeholder warnings for the 2 target files

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the `prepare:docs` rewrite step to tweak markdown text, with no runtime/application logic changes.
> 
> **Overview**
> Improves `fixKnownDocsIssues()` in `scripts/prepare-docs.mjs` to clean up generated docs content.
> 
> During `prepare:docs`, it now replaces the webpack config placeholder `... // blah blah` with `// ... other aliases` in `how-to-use-different-files-for-client-and-server-rendering.md`, and rewrites an incomplete “(todo reference)” note in `images.md` into a single clear sentence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7a96ec8c27f40be122b7fb2a8d9230e5437d2fe. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->