### PR TITLE
Promote evaluator paths to the comparison guide

### DIFF
--- a/prototypes/docusaurus/src/pages/examples.tsx
+++ b/prototypes/docusaurus/src/pages/examples.tsx
@@ -9,9 +9,9 @@ const evaluationPaths = [
     eyebrow: 'Evaluator path',
     title: 'Compare setup approaches',
     description:
-      'Start with the docs landing page to choose between new app setup, existing app install, migration, or Pro evaluation.',
-    href: '/docs',
-    cta: 'Open the docs guide',
+      'Read the evaluator guide first to compare React on Rails with Hotwire/Turbo, Inertia Rails, and react-rails.',
+    href: '/docs/getting-started/comparing-react-on-rails-to-alternatives',
+    cta: 'Open the comparison guide',
   },
   {
     eyebrow: 'Migration path',

--- a/prototypes/docusaurus/src/pages/index.tsx
+++ b/prototypes/docusaurus/src/pages/index.tsx
@@ -34,9 +34,9 @@ const personaPaths = [
     eyebrow: 'Persona D',
     title: 'Evaluating Rails + React options',
     description:
-      'Review example apps, migration references, and concrete paths from react-rails or vite_rails.',
-    href: '/examples',
-    cta: 'Evaluate the ecosystem fit',
+      'Compare React on Rails with Hotwire/Turbo, Inertia Rails, and react-rails before you dive into migration details.',
+    href: '/docs/getting-started/comparing-react-on-rails-to-alternatives',
+    cta: 'Compare the options',
   },
 ];
 
@@ -66,6 +66,12 @@ const recommendedFlows = [
 
 const migrationGuides = [
   {
+    title: 'Compare Rails + React approaches',
+    description:
+      'Use the new evaluator guide first, then branch into concrete migration docs if React on Rails is the right fit.',
+    href: '/docs/getting-started/comparing-react-on-rails-to-alternatives',
+  },
+  {
     title: 'Migrate from react-rails',
     description:
       'Swap from `react-rails` to React on Rails with a migration checklist grounded in a real sample app.',
@@ -74,7 +80,7 @@ const migrationGuides = [
   {
     title: 'Browse sample apps',
     description:
-      'Open repositories that show canonical SSR, migration, and evaluation workflows without marketing detours.',
+      'Open repositories that back the migration and evaluation docs with concrete examples.',
     href: '/examples',
   },
 ];

--- a/scripts/prepare-docs.mjs
+++ b/scripts/prepare-docs.mjs
@@ -508,8 +508,9 @@ React on Rails is one product with two tiers: open source for Rails + React inte
 
 ### Evaluating Rails + React options
 
-- [Examples and migration references](/examples)
+- [Compare React on Rails to alternatives](./getting-started/comparing-react-on-rails-to-alternatives.md)
 - [Migrate from react-rails](./migrating/migrating-from-react-rails.md)
+- [Examples and migration references](/examples)
 
 ## Dive deeper when you need it
 

--- a/scripts/sync-docs.mjs
+++ b/scripts/sync-docs.mjs
@@ -22,6 +22,7 @@ const subsetPaths = [
   "oss/getting-started/quick-start.md",
   "oss/getting-started/tutorial.md",
   "oss/getting-started/installation-into-an-existing-rails-app.md",
+  "oss/getting-started/comparing-react-on-rails-to-alternatives.md",
   "oss/core-concepts/how-react-on-rails-works.md",
   "oss/core-concepts/react-server-rendering.md",
   "oss/api-reference/view-helpers-api.md",
@@ -30,7 +31,7 @@ const subsetPaths = [
   "oss/upgrading/upgrading-react-on-rails.md",
   "pro/react-on-rails-pro.md",
   "pro/home-pro.md",
-  "pro/node-renderer/basics.md",
+  "oss/building-features/node-renderer/basics.md",
   "pro/react-server-components/tutorial.md"
 ];
 


### PR DESCRIPTION
## Summary
- route evaluator personas directly to the new comparison guide instead of making them infer it from the docs landing or examples page
- update the generated `/docs` landing content so evaluation starts with the comparison page, then branches into migration/examples
- fix the docs subset sync list so subset builds include the new comparison guide and the correct node-renderer basics page

## Why
The first site IA pass created a persona-friendly shell, but the evaluator path still stopped one click too early. This PR makes the comparison guide the first-class destination for evaluator traffic so the docs feel closer to the reactnative.dev model of one obvious next step.

## Validation
- `REACT_ON_RAILS_REPO=/tmp/react-on-rails-evaluator-SUXDwP npm run prepare`
- `npm run build`
- `REACT_ON_RAILS_REPO=/tmp/react-on-rails-evaluator-SUXDwP npm run prepare:subset`
- browser spot checks on `/` and `/docs/getting-started/comparing-react-on-rails-to-alternatives`

## Notes
- This PR is stacked on top of #17.
- The subset sync also had a pre-existing bad path for node renderer basics; this PR corrects it while touching that workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes site navigation targets and the docs subset sync list; mistakes could lead to broken links or missing docs in subset builds.
> 
> **Overview**
> Updates the Docusaurus `Home` and `Examples` pages so evaluator-focused CTAs route directly to the new comparison guide (`/docs/getting-started/comparing-react-on-rails-to-alternatives`) instead of sending users to `/docs` or `/examples` first.
> 
> Adjusts the generated `/docs` landing content to **promote the comparison guide** as the first step under evaluation, then links out to migration and examples.
> 
> Fixes the docs subset sync configuration to include the new comparison guide and correct the `node-renderer/basics.md` path so subset builds copy the intended file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc4a28f52399bc26a6a668ed20ead1fc7d6792d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->