### PR TITLE
Set /docs/pro as canonical Pro docs landing page

### DIFF
--- a/CLOUDFLARE_SETUP.md
+++ b/CLOUDFLARE_SETUP.md
@@ -36,7 +36,6 @@ Configured in `prototypes/docusaurus/static/_redirects`:
 
 - `/react-on-rails/docs/*` → `/docs/*` (301)
 - `/react-on-rails-pro/docs/*` → `/docs/*` (301)
-- `/docs/pro` → `/docs/pro/react-on-rails-pro` (302)
 
 ### Legacy host redirects (shakacode.com Cloudflare project)
 

--- a/prototypes/docusaurus/docusaurus.config.ts
+++ b/prototypes/docusaurus/docusaurus.config.ts
@@ -75,7 +75,7 @@ const config: Config = {
           position: 'left',
           label: 'Docs',
         },
-        {to: '/docs/pro/react-on-rails-pro', label: 'Pro Docs', position: 'left'},
+        {to: '/docs/pro', label: 'Pro Docs', position: 'left'},
         {to: '/examples', label: 'Examples', position: 'left'},
         {to: '/pro', label: 'Pro Plans', position: 'left'},
         {
@@ -101,7 +101,7 @@ const config: Config = {
               to: '/docs/introduction',
             },
             {label: 'Quick Start', to: '/docs/getting-started/quick-start'},
-            {label: 'React on Rails Pro', to: '/docs/pro/react-on-rails-pro'},
+            {label: 'React on Rails Pro', to: '/docs/pro'},
           ],
         },
         {

--- a/prototypes/docusaurus/src/pages/pro.tsx
+++ b/prototypes/docusaurus/src/pages/pro.tsx
@@ -44,7 +44,7 @@ export default function ProPage(): ReactNode {
               production support. You can evaluate Pro without a license.
             </p>
             <div className={styles.actions}>
-              <Link className="button button--primary button--lg" to="/docs/pro/react-on-rails-pro">
+              <Link className="button button--primary button--lg" to="/docs/pro">
                 Try Pro Free (No License)
               </Link>
               <Link

--- a/prototypes/docusaurus/static/_redirects
+++ b/prototypes/docusaurus/static/_redirects
@@ -2,4 +2,3 @@
 /react-on-rails/docs /docs 301
 /react-on-rails-pro/docs/* /docs/:splat 301
 /react-on-rails-pro/docs /docs 301
-/docs/pro /docs/pro/react-on-rails-pro 302

--- a/scripts/prepare-docs.mjs
+++ b/scripts/prepare-docs.mjs
@@ -436,12 +436,23 @@ async function injectProFriendlyNotice(docsRoot) {
   }
 
   const original = await fs.readFile(proIntroPath, "utf8");
-  if (original.includes("Friendly evaluation policy")) {
-    return;
+  let updated = original;
+
+  // Inject slug so this doc serves at /docs/pro/ instead of /docs/pro/react-on-rails-pro
+  if (!updated.includes("slug:")) {
+    if (updated.startsWith("---")) {
+      // Existing frontmatter — insert slug after opening ---
+      updated = updated.replace(/^---\n/, "---\nslug: /pro\n");
+    } else {
+      // No frontmatter — add it
+      updated = `---\nslug: /pro\n---\n\n${updated}`;
+    }
   }
 
-  const notice = `> **Friendly evaluation policy**\n> You can evaluate React on Rails Pro without a license.\n> If your organization is budget-constrained, email [justin@shakacode.com](mailto:justin@shakacode.com). We can provide free licenses in qualifying cases.\n\n`;
-  const updated = original.replace(/^# React on Rails Pro\s*\n+/, `# React on Rails Pro\n\n${notice}`);
+  if (!updated.includes("Friendly evaluation policy")) {
+    const notice = `> **Friendly evaluation policy**\n> You can evaluate React on Rails Pro without a license.\n> If your organization is budget-constrained, email [justin@shakacode.com](mailto:justin@shakacode.com). We can provide free licenses in qualifying cases.\n\n`;
+    updated = updated.replace(/^# React on Rails Pro\s*\n+/m, `# React on Rails Pro\n\n${notice}`);
+  }
 
   if (updated !== original) {
     await fs.writeFile(proIntroPath, updated, "utf8");
@@ -457,7 +468,7 @@ Welcome to the React on Rails docs.
 - [Quick Start](./getting-started/quick-start.md)
 - [Installation](./getting-started/installation-into-an-existing-rails-app.md)
 - [API Reference](./api-reference/view-helpers-api.md)
-- [Pro Documentation](./pro/react-on-rails-pro.md)
+- [Pro Documentation](/docs/pro)
 - [Legacy Archive](./archive/legacy/README.md)
 
 React on Rails Pro is friendly to evaluate:


### PR DESCRIPTION
## Summary

Establishes `/docs/pro` as the canonical landing page for React on Rails Pro documentation instead of `/docs/pro/react-on-rails-pro`. 

Changes:
- Inject `slug: /pro` into `react-on-rails-pro.md` frontmatter to serve at `/docs/pro` directly
- Update all navigation links (navbar, footer, pro.tsx) to point to `/docs/pro`
- Remove unnecessary 302 redirect
- Clean separation: `/pro` for Pro Plans, `/docs/pro` for Pro Docs

This fixes the 404 issue where shakacode.com redirects to `/docs/pro`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the canonical URL and routing for Pro documentation, which could break inbound links or redirects if misconfigured, but is limited to documentation/navigation and build-time rewriting.
> 
> **Overview**
> Sets `/docs/pro` as the canonical React on Rails Pro docs entrypoint by **updating site navigation and CTA links** (navbar, footer, `/pro` page) to target `/docs/pro` instead of `/docs/pro/react-on-rails-pro`.
> 
> Updates the docs build pipeline (`scripts/prepare-docs.mjs`) to **inject `slug: /pro`** into `pro/react-on-rails-pro.md` frontmatter (and only inject the friendly notice if missing), and removes the now-unneeded `/docs/pro` → `/docs/pro/react-on-rails-pro` redirect from `_redirects`. Documentation for Cloudflare redirect strategy is adjusted accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5061aa5e9b72f56eabc108c1ef9a74b23fd2dede. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Simplified and unified Pro documentation navigation paths across the platform for improved discoverability and better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->