### PR TITLE
Add sequential numbering instruction to address-review

### DIFF
--- a/.claude/commands/address-review.md
+++ b/.claude/commands/address-review.md
@@ -95,6 +95,7 @@ Create a todo list with TodoWrite containing **only the `MUST-FIX` items**:
 
 Present the triage to the user - **DO NOT automatically start addressing items**:
 
+- Number all items sequentially across categories so users can reference any item by number
 - `MUST-FIX ({count})`: list the todos created
 - `DISCUSS ({count})`: list items needing user choice, with a short reason
 - `SKIPPED ({count})`: list skipped comments with a short reason, including duplicates and factually incorrect suggestions


### PR DESCRIPTION
Clarifies that all items should be numbered sequentially across categories (MUST-FIX, DISCUSS, SKIPPED) so users can reference any item by number when selecting which to address.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts output formatting guidance; no runtime or data-handling code is affected.
> 
> **Overview**
> Updates `.claude/commands/address-review.md` to require **sequential numbering across `MUST-FIX`, `DISCUSS`, and `SKIPPED`** items when presenting triage, so users can reference any item by a single number when selecting what to address.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd4e57307c6e65ba601bf4d6cb458e5d9eefe20f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->