### PR TITLE
Style variant: soft GitHub docs

### DIFF
--- a/prototypes/docusaurus/src/css/custom.css
+++ b/prototypes/docusaurus/src/css/custom.css
@@ -25,10 +25,10 @@
   --ifm-footer-color: #57606a;
   --ifm-menu-color: #57606a;
   --ifm-menu-color-active: #24292f;
-  --site-border: #d0d7de;
+  --site-border: #d8dee4;
   --site-surface: #ffffff;
-  --site-soft-surface: #f6f8fa;
-  --site-inline-code-surface: #f6f8fa;
+  --site-soft-surface: #f8fbff;
+  --site-inline-code-surface: #f2f8ff;
   --site-inline-code-text: #24292f;
 }
 
@@ -93,7 +93,7 @@ body {
 }
 
 .menu__link--active {
-  background: rgba(9, 105, 218, 0.1);
+  background: rgba(9, 105, 218, 0.08);
   color: var(--ifm-color-primary-dark);
   font-weight: 600;
 }
@@ -113,12 +113,12 @@ body {
 
 .pagination-nav__link {
   border: 1px solid var(--site-border);
-  border-radius: 8px;
+  border-radius: 10px;
   box-shadow: none;
 }
 
 .button {
-  border-radius: 6px;
+  border-radius: 8px;
   font-weight: 600;
   box-shadow: none;
 }
@@ -134,7 +134,7 @@ body {
 }
 
 .button--secondary {
-  background: var(--site-surface);
+  background: #f8fbff;
   border: 1px solid var(--site-border);
   color: var(--ifm-color-content);
 }

--- a/prototypes/docusaurus/src/pages/examples.module.css
+++ b/prototypes/docusaurus/src/pages/examples.module.css
@@ -1,12 +1,12 @@
 .main {
-  padding-bottom: 3rem;
+  padding-bottom: 3.2rem;
 }
 
 .hero {
-  padding: 3rem 0 2.4rem;
-  margin-bottom: 2rem;
+  padding: 3.4rem 0 2.7rem;
+  margin-bottom: 2.2rem;
   border-bottom: 1px solid var(--site-border);
-  background: var(--site-soft-surface);
+  background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%);
 }
 
 .kicker,
@@ -36,7 +36,7 @@
 
 .sectionHeader {
   max-width: 38rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.2rem;
 }
 
 .sectionHeader h2 {
@@ -44,35 +44,35 @@
 }
 
 .grid {
-  margin-bottom: 2rem;
+  margin-bottom: 2.2rem;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .card {
   border: 1px solid var(--site-border);
-  border-radius: 10px;
+  border-radius: 12px;
   background: var(--site-surface);
-  padding: 1.05rem;
+  padding: 1.2rem;
   box-shadow: none;
 }
 
 .card h3 {
-  margin-bottom: 0.55rem;
+  margin-bottom: 0.65rem;
   line-height: 1.12;
 }
 
 .cardLink {
   display: inline-flex;
   align-items: center;
-  margin-top: 0.2rem;
+  margin-top: 0.1rem;
   font-weight: 700;
 }
 
 @media (max-width: 996px) {
   .hero {
-    padding: 2.4rem 0 2rem;
+    padding: 2.7rem 0 2.2rem;
   }
 
   .grid {

--- a/prototypes/docusaurus/src/pages/index.module.css
+++ b/prototypes/docusaurus/src/pages/index.module.css
@@ -1,13 +1,13 @@
 .heroBanner {
-  padding: 3.25rem 0 2.75rem;
+  padding: 3.7rem 0 3.15rem;
   border-bottom: 1px solid var(--site-border);
-  background: var(--site-soft-surface);
+  background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%);
 }
 
 .heroLayout {
   display: grid;
   grid-template-columns: minmax(0, 1.6fr) minmax(18rem, 0.95fr);
-  gap: 1rem;
+  gap: 1.2rem;
   align-items: end;
 }
 
@@ -17,9 +17,9 @@
 
 .heroPanel {
   border: 1px solid var(--site-border);
-  border-radius: 10px;
-  padding: 1rem;
-  background: var(--site-surface);
+  border-radius: 12px;
+  padding: 1.2rem;
+  background: #fcfdff;
 }
 
 .kicker,
@@ -44,9 +44,9 @@
 }
 
 .title {
-  max-width: 14ch;
-  margin-bottom: 0.85rem;
-  font-size: clamp(2.05rem, 5vw, 3.25rem);
+  max-width: 15ch;
+  margin-bottom: 1rem;
+  font-size: clamp(2.1rem, 5.3vw, 3.35rem);
   line-height: 1.12;
   letter-spacing: -0.02em;
 }
@@ -60,9 +60,9 @@
 }
 
 .buttons {
-  margin-top: 1.2rem;
+  margin-top: 1.35rem;
   display: flex;
-  gap: 0.75rem;
+  gap: 0.8rem;
   flex-wrap: wrap;
 }
 
@@ -83,17 +83,17 @@
 .section,
 .sectionSoft,
 .sectionInk {
-  padding: 3rem 0;
+  padding: 3.3rem 0;
 }
 
 .sectionSoft {
-  background: var(--site-soft-surface);
+  background: #f8fbff;
   border-top: 1px solid var(--site-border);
   border-bottom: 1px solid var(--site-border);
 }
 
 .sectionInk {
-  background: var(--site-soft-surface);
+  background: #f8fbff;
   color: var(--ifm-color-content);
   border-top: 1px solid var(--site-border);
   border-bottom: 1px solid var(--site-border);
@@ -105,7 +105,7 @@
 
 .sectionHeader {
   max-width: 42rem;
-  margin-bottom: 1.2rem;
+  margin-bottom: 1.4rem;
 }
 
 .sectionHeader h2 {
@@ -118,7 +118,7 @@
 .flowGrid,
 .migrationGrid {
   display: grid;
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .personaGrid {
@@ -135,9 +135,9 @@
 .migrationCard,
 .quoteCard {
   border: 1px solid var(--site-border);
-  border-radius: 10px;
+  border-radius: 12px;
   background: var(--site-surface);
-  padding: 1.1rem;
+  padding: 1.2rem;
   box-shadow: none;
 }
 
@@ -149,16 +149,16 @@
 }
 
 .flowSummary {
-  min-height: 5rem;
+  min-height: 5.3rem;
   color: var(--ifm-color-content-secondary);
 }
 
 .inlineCode {
   display: block;
   margin: 0 0 1rem;
-  padding: 0.7rem 0.8rem;
+  padding: 0.75rem 0.85rem;
   border: 1px solid var(--site-border);
-  border-radius: 8px;
+  border-radius: 10px;
   background: var(--site-inline-code-surface);
   color: var(--ifm-color-content);
   overflow-x: auto;
@@ -174,7 +174,7 @@
 .quoteGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .quoteCard {
@@ -189,7 +189,7 @@
 }
 
 .quoteCard footer {
-  margin-top: 1rem;
+  margin-top: 1.1rem;
   display: flex;
   flex-direction: column;
   gap: 0.15rem;
@@ -198,7 +198,7 @@
 
 @media (max-width: 996px) {
   .heroBanner {
-    padding: 2.6rem 0 2.2rem;
+    padding: 2.8rem 0 2.3rem;
   }
 
   .heroLayout,

--- a/prototypes/docusaurus/src/pages/pro.module.css
+++ b/prototypes/docusaurus/src/pages/pro.module.css
@@ -1,11 +1,11 @@
 .main {
-  padding-bottom: 3rem;
+  padding-bottom: 3.2rem;
 }
 
 .hero {
-  padding: 3rem 0 2.4rem;
-  margin-bottom: 1.8rem;
-  background: var(--site-soft-surface);
+  padding: 3.3rem 0 2.6rem;
+  margin-bottom: 2.1rem;
+  background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%);
   color: var(--ifm-color-content);
   border-top: 1px solid var(--site-border);
   border-bottom: 1px solid var(--site-border);
@@ -25,29 +25,29 @@
 }
 
 .actions {
-  margin-top: 1.2rem;
+  margin-top: 1.35rem;
   display: flex;
-  gap: 0.75rem;
+  gap: 0.8rem;
   flex-wrap: wrap;
 }
 
 .grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
-  margin-bottom: 1.6rem;
+  gap: 1.1rem;
+  margin-bottom: 1.9rem;
 }
 
 .policyCard {
   border: 1px solid var(--site-border);
-  border-radius: 10px;
+  border-radius: 12px;
   background: var(--site-surface);
-  padding: 1.05rem;
+  padding: 1.2rem;
   box-shadow: none;
 }
 
 .policyCard h2 {
-  margin-bottom: 0.45rem;
+  margin-bottom: 0.55rem;
   font-size: 1.1rem;
 }
 
@@ -61,19 +61,19 @@
 
 .stepList {
   list-style: none;
-  margin: 1rem 0 0;
+  margin: 1.1rem 0 0;
   padding: 0;
 }
 
 .stepList li {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.8rem;
+  gap: 0.85rem;
   align-items: start;
 }
 
 .stepList li + li {
-  margin-top: 0.9rem;
+  margin-top: 1rem;
 }
 
 .stepList p {
@@ -96,7 +96,7 @@
 .tableWrap {
   overflow-x: auto;
   border: 1px solid var(--site-border);
-  border-radius: 10px;
+  border-radius: 12px;
 }
 
 .table {
@@ -106,7 +106,7 @@
 
 .table th,
 .table td {
-  padding: 0.8rem;
+  padding: 0.9rem;
   border-bottom: 1px solid var(--site-border);
   text-align: left;
 }


### PR DESCRIPTION
## Summary
- provide a softer GitHub-like docs variant optimized for long reading
- use gentler borders, slightly larger cards, and subtle section gradients
- keep the information architecture unchanged while shifting only visual tone

## Testing
- npm --prefix prototypes/docusaurus run build (passes, with existing broken anchor warning in tutorial docs)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only visual tweaks (colors, spacing, radii, subtle gradients) with no logic or data-flow changes; risk is limited to minor layout/contrast regressions across pages.
> 
> **Overview**
> Updates the Docusaurus prototype styling to a *softer GitHub-docs-inspired* look by lightening border/surface tokens (including inline-code backgrounds) and reducing the active menu highlight intensity.
> 
> Across the `index`, `examples`, and `pro` pages, adjusts spacing and sizing (padding, gaps, card/button radii) and replaces flat soft-surface backgrounds with subtle top-to-bottom gradients for hero/section areas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c9de4503dfec510ce950be912457fc5b9feed4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined design tokens with updated color values and visual styling adjustments across documentation pages.
  * Enhanced component spacing and layout consistency through padding, margin, and border-radius refinements.
  * Improved visual hierarchy and design system alignment across multiple sections and components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->