### PR TITLE
Style variant: high-contrast ink docs

### DIFF
--- a/prototypes/docusaurus/src/css/custom.css
+++ b/prototypes/docusaurus/src/css/custom.css
@@ -1,11 +1,11 @@
 :root {
-  --ifm-color-primary: #0969da;
-  --ifm-color-primary-dark: #0550ae;
-  --ifm-color-primary-darker: #033d8b;
-  --ifm-color-primary-darkest: #022f6d;
-  --ifm-color-primary-light: #218bff;
-  --ifm-color-primary-lighter: #54aeff;
-  --ifm-color-primary-lightest: #80ccff;
+  --ifm-color-primary: #1f6feb;
+  --ifm-color-primary-dark: #1a5cc2;
+  --ifm-color-primary-darker: #14489a;
+  --ifm-color-primary-darkest: #0f3776;
+  --ifm-color-primary-light: #3b82f6;
+  --ifm-color-primary-lighter: #5a9bf8;
+  --ifm-color-primary-lightest: #84b8fb;
   --ifm-background-color: #ffffff;
   --ifm-background-surface-color: #ffffff;
   --ifm-font-family-base: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
@@ -17,19 +17,19 @@
   --ifm-heading-line-height: 1.25;
   --ifm-code-font-size: 85%;
   --ifm-heading-font-weight: 600;
-  --ifm-color-content: #24292f;
-  --ifm-color-content-secondary: #57606a;
-  --docusaurus-highlighted-code-line-bg: rgba(9, 105, 218, 0.12);
+  --ifm-color-content: #1f2328;
+  --ifm-color-content-secondary: #4a5560;
+  --docusaurus-highlighted-code-line-bg: rgba(31, 111, 235, 0.14);
   --ifm-navbar-background-color: #ffffff;
-  --ifm-footer-background-color: #f6f8fa;
-  --ifm-footer-color: #57606a;
-  --ifm-menu-color: #57606a;
-  --ifm-menu-color-active: #24292f;
-  --site-border: #d0d7de;
+  --ifm-footer-background-color: #f3f4f6;
+  --ifm-footer-color: #4a5560;
+  --ifm-menu-color: #4a5560;
+  --ifm-menu-color-active: #1f2328;
+  --site-border: #c5cdd5;
   --site-surface: #ffffff;
-  --site-soft-surface: #f6f8fa;
-  --site-inline-code-surface: #f6f8fa;
-  --site-inline-code-text: #24292f;
+  --site-soft-surface: #f3f4f6;
+  --site-inline-code-surface: #f0f2f5;
+  --site-inline-code-text: #1f2328;
 }
 
 [data-theme='dark'] {
@@ -86,15 +86,15 @@ body {
 }
 
 .menu__link {
-  border-radius: 6px;
+  border-radius: 4px;
   font-size: 0.92rem;
   line-height: 1.35;
   font-weight: 500;
 }
 
 .menu__link--active {
-  background: rgba(9, 105, 218, 0.1);
-  color: var(--ifm-color-primary-dark);
+  background: rgba(31, 35, 40, 0.08);
+  color: var(--ifm-color-content);
   font-weight: 600;
 }
 
@@ -113,12 +113,12 @@ body {
 
 .pagination-nav__link {
   border: 1px solid var(--site-border);
-  border-radius: 8px;
+  border-radius: 6px;
   box-shadow: none;
 }
 
 .button {
-  border-radius: 6px;
+  border-radius: 4px;
   font-weight: 600;
   box-shadow: none;
 }
@@ -136,7 +136,7 @@ body {
 .button--secondary {
   background: var(--site-surface);
   border: 1px solid var(--site-border);
-  color: var(--ifm-color-content);
+  color: var(--ifm-color-content-secondary);
 }
 
 .button--secondary:hover {

--- a/prototypes/docusaurus/src/pages/examples.module.css
+++ b/prototypes/docusaurus/src/pages/examples.module.css
@@ -5,8 +5,9 @@
 .hero {
   padding: 3rem 0 2.4rem;
   margin-bottom: 2rem;
+  border-top: 1px solid var(--site-border);
   border-bottom: 1px solid var(--site-border);
-  background: var(--site-soft-surface);
+  background: var(--site-surface);
 }
 
 .kicker,
@@ -14,7 +15,7 @@
 .cardEyebrow {
   margin: 0 0 0.7rem;
   text-transform: uppercase;
-  letter-spacing: 0.06rem;
+  letter-spacing: 0.07rem;
   font-size: 0.75rem;
   font-weight: 700;
 }
@@ -36,7 +37,7 @@
 
 .sectionHeader {
   max-width: 38rem;
-  margin-bottom: 1rem;
+  margin-bottom: 0.9rem;
 }
 
 .sectionHeader h2 {
@@ -47,14 +48,14 @@
   margin-bottom: 2rem;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 0.95rem;
 }
 
 .card {
   border: 1px solid var(--site-border);
-  border-radius: 10px;
-  background: var(--site-surface);
-  padding: 1.05rem;
+  border-radius: 6px;
+  background: var(--site-soft-surface);
+  padding: 1rem;
   box-shadow: none;
 }
 

--- a/prototypes/docusaurus/src/pages/index.module.css
+++ b/prototypes/docusaurus/src/pages/index.module.css
@@ -1,13 +1,14 @@
 .heroBanner {
   padding: 3.25rem 0 2.75rem;
+  border-top: 1px solid var(--site-border);
   border-bottom: 1px solid var(--site-border);
-  background: var(--site-soft-surface);
+  background: var(--site-surface);
 }
 
 .heroLayout {
   display: grid;
   grid-template-columns: minmax(0, 1.6fr) minmax(18rem, 0.95fr);
-  gap: 1rem;
+  gap: 1.1rem;
   align-items: end;
 }
 
@@ -17,9 +18,9 @@
 
 .heroPanel {
   border: 1px solid var(--site-border);
-  border-radius: 10px;
+  border-radius: 6px;
   padding: 1rem;
-  background: var(--site-surface);
+  background: var(--site-soft-surface);
 }
 
 .kicker,
@@ -28,7 +29,7 @@
 .cardEyebrow {
   margin: 0 0 0.7rem;
   text-transform: uppercase;
-  letter-spacing: 0.06rem;
+  letter-spacing: 0.07rem;
   font-size: 0.75rem;
   font-weight: 700;
 }
@@ -46,9 +47,9 @@
 .title {
   max-width: 14ch;
   margin-bottom: 0.85rem;
-  font-size: clamp(2.05rem, 5vw, 3.25rem);
+  font-size: clamp(2rem, 4.9vw, 3.15rem);
   line-height: 1.12;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.015em;
 }
 
 .subtitle {
@@ -83,7 +84,7 @@
 .section,
 .sectionSoft,
 .sectionInk {
-  padding: 3rem 0;
+  padding: 2.9rem 0;
 }
 
 .sectionSoft {
@@ -105,7 +106,7 @@
 
 .sectionHeader {
   max-width: 42rem;
-  margin-bottom: 1.2rem;
+  margin-bottom: 1.1rem;
 }
 
 .sectionHeader h2 {
@@ -118,7 +119,7 @@
 .flowGrid,
 .migrationGrid {
   display: grid;
-  gap: 1rem;
+  gap: 0.95rem;
 }
 
 .personaGrid {
@@ -135,9 +136,9 @@
 .migrationCard,
 .quoteCard {
   border: 1px solid var(--site-border);
-  border-radius: 10px;
+  border-radius: 6px;
   background: var(--site-surface);
-  padding: 1.1rem;
+  padding: 1rem;
   box-shadow: none;
 }
 
@@ -156,9 +157,9 @@
 .inlineCode {
   display: block;
   margin: 0 0 1rem;
-  padding: 0.7rem 0.8rem;
+  padding: 0.65rem 0.75rem;
   border: 1px solid var(--site-border);
-  border-radius: 8px;
+  border-radius: 6px;
   background: var(--site-inline-code-surface);
   color: var(--ifm-color-content);
   overflow-x: auto;
@@ -174,7 +175,7 @@
 .quoteGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 0.95rem;
 }
 
 .quoteCard {

--- a/prototypes/docusaurus/src/pages/pro.module.css
+++ b/prototypes/docusaurus/src/pages/pro.module.css
@@ -5,7 +5,7 @@
 .hero {
   padding: 3rem 0 2.4rem;
   margin-bottom: 1.8rem;
-  background: var(--site-soft-surface);
+  background: var(--site-surface);
   color: var(--ifm-color-content);
   border-top: 1px solid var(--site-border);
   border-bottom: 1px solid var(--site-border);
@@ -15,7 +15,7 @@
 .cardEyebrow {
   margin: 0 0 0.7rem;
   text-transform: uppercase;
-  letter-spacing: 0.06rem;
+  letter-spacing: 0.07rem;
   font-size: 0.75rem;
   font-weight: 700;
 }
@@ -27,22 +27,22 @@
 .actions {
   margin-top: 1.2rem;
   display: flex;
-  gap: 0.75rem;
+  gap: 0.7rem;
   flex-wrap: wrap;
 }
 
 .grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 0.95rem;
   margin-bottom: 1.6rem;
 }
 
 .policyCard {
   border: 1px solid var(--site-border);
-  border-radius: 10px;
-  background: var(--site-surface);
-  padding: 1.05rem;
+  border-radius: 6px;
+  background: var(--site-soft-surface);
+  padding: 1rem;
   box-shadow: none;
 }
 
@@ -73,7 +73,7 @@
 }
 
 .stepList li + li {
-  margin-top: 0.9rem;
+  margin-top: 0.8rem;
 }
 
 .stepList p {
@@ -87,16 +87,17 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
-  background: rgba(9, 105, 218, 0.1);
-  color: var(--ifm-color-primary-dark);
+  border-radius: 6px;
+  border: 1px solid var(--site-border);
+  background: var(--site-surface);
+  color: var(--ifm-color-content);
   font-weight: 700;
 }
 
 .tableWrap {
   overflow-x: auto;
   border: 1px solid var(--site-border);
-  border-radius: 10px;
+  border-radius: 6px;
 }
 
 .table {
@@ -112,7 +113,7 @@
 }
 
 .table th {
-  background: var(--site-soft-surface);
+  background: var(--site-surface);
 }
 
 .note {


### PR DESCRIPTION
## Summary
- provide a crisp, high-contrast docs variant with neutral surfaces and stronger text hierarchy
- reduce decorative color usage while keeping GitHub-adjacent structure and components
- apply the style consistently across home, examples, and pro pages

## Testing
- npm --prefix prototypes/docusaurus run build (passes, with existing broken anchor warning in tutorial docs)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to CSS token and layout styling updates with no functional or data-handling impact.
> 
> **Overview**
> Updates the Docusaurus prototype styling to a higher-contrast, more neutral “ink” look by retuning core design tokens in `custom.css` (primary palette, text colors, borders/surfaces, code highlight color).
> 
> Applies the new surface/border treatment across the `index`, `examples`, and `pro` pages (hero backgrounds now use `--site-surface` with top borders; cards and UI elements get smaller border radii, tighter spacing, and adjusted active/secondary states such as `menu__link--active`, pagination, buttons, and step badges).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81fae411e0aa62b60d390d6c24d29744368b3af5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->