### PR TITLE
Style variant: prior blue restore (no warm tones)

### DIFF
--- a/prototypes/docusaurus/src/css/custom.css
+++ b/prototypes/docusaurus/src/css/custom.css
@@ -118,7 +118,7 @@ body {
 }
 
 .button {
-  border-radius: 6px;
+  border-radius: 14px;
   font-weight: 600;
   box-shadow: none;
 }

--- a/prototypes/docusaurus/src/pages/index.module.css
+++ b/prototypes/docusaurus/src/pages/index.module.css
@@ -1,13 +1,23 @@
 .heroBanner {
-  padding: 3.25rem 0 2.75rem;
+  position: relative;
+  overflow: hidden;
+  padding: 4.35rem 0 3.5rem;
+  border-top: 1px solid var(--site-border);
   border-bottom: 1px solid var(--site-border);
-  background: var(--site-soft-surface);
+  background:
+    linear-gradient(to right, rgba(148, 163, 184, 0.18) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(148, 163, 184, 0.14) 1px, transparent 1px),
+    linear-gradient(180deg, #edf3fb 0%, #f3f7fc 100%);
+  background-size:
+    96px 100%,
+    100% 96px,
+    auto;
 }
 
 .heroLayout {
   display: grid;
   grid-template-columns: minmax(0, 1.6fr) minmax(18rem, 0.95fr);
-  gap: 1rem;
+  gap: 1.5rem;
   align-items: end;
 }
 
@@ -16,20 +26,54 @@
 }
 
 .heroPanel {
+  position: relative;
+  overflow: hidden;
   border: 1px solid var(--site-border);
-  border-radius: 10px;
-  padding: 1rem;
-  background: var(--site-surface);
+  border-radius: 20px;
+  padding: 3.15rem 1.2rem 1rem;
+  background: #f7f9fc;
+}
+
+.heroPanel::before {
+  content: "quickstart.sh";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2.35rem;
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.98rem;
+  font-weight: 600;
+  color: #5a6678;
+  border-bottom: 1px solid var(--site-border);
+  background: #f2f5fa;
+}
+
+.heroPanel::after {
+  content: "";
+  position: absolute;
+  top: 0.95rem;
+  right: 1rem;
+  width: 0.62rem;
+  height: 0.62rem;
+  border-radius: 999px;
+  background: #90b3e8;
+  box-shadow:
+    -1.05rem 0 0 #aec7ec,
+    -2.1rem 0 0 #c7d8f2;
 }
 
 .kicker,
 .panelLabel,
 .sectionEyebrow,
 .cardEyebrow {
-  margin: 0 0 0.7rem;
+  margin: 0 0 0.75rem;
   text-transform: uppercase;
-  letter-spacing: 0.06rem;
-  font-size: 0.75rem;
+  letter-spacing: 0.095rem;
+  font-size: 0.8rem;
   font-weight: 700;
 }
 
@@ -40,60 +84,77 @@
 
 .panelLabel,
 .cardEyebrow {
-  color: var(--ifm-color-content-secondary);
+  color: #0969da;
 }
 
 .title {
-  max-width: 14ch;
-  margin-bottom: 0.85rem;
-  font-size: clamp(2.05rem, 5vw, 3.25rem);
-  line-height: 1.12;
-  letter-spacing: -0.02em;
+  max-width: 11ch;
+  margin-bottom: 1rem;
+  font-size: clamp(2.95rem, 6.4vw, 5rem);
+  line-height: 0.98;
+  letter-spacing: -0.03em;
 }
 
 .subtitle {
   max-width: 40rem;
   margin-bottom: 0;
-  font-size: clamp(1rem, 1.75vw, 1.18rem);
+  font-size: clamp(1.08rem, 1.9vw, 1.34rem);
   line-height: 1.55;
   color: var(--ifm-color-content-secondary);
 }
 
 .buttons {
-  margin-top: 1.2rem;
+  margin-top: 1.45rem;
   display: flex;
-  gap: 0.75rem;
+  gap: 0.85rem;
   flex-wrap: wrap;
 }
 
 .heroSteps {
   margin: 0;
-  padding-left: 1.1rem;
+  padding: 0.9rem 1rem;
+  list-style: none;
+  border: 1px solid #c5d5ea;
+  border-radius: 14px;
+  background: #ebf2fb;
 }
 
 .heroSteps li + li {
-  margin-top: 0.45rem;
+  margin-top: 0.35rem;
+}
+
+.heroSteps code {
+  display: block;
+  padding: 0.18rem 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #0969da;
+  font-size: 1.03rem;
+  font-family: var(--ifm-font-family-monospace);
 }
 
 .panelNote {
-  margin: 1rem 0 0;
+  margin: 0.95rem 0 0;
+  padding-top: 0.95rem;
+  border-top: 1px solid #cfd9e7;
   color: var(--ifm-color-content-secondary);
 }
 
 .section,
 .sectionSoft,
 .sectionInk {
-  padding: 3rem 0;
+  padding: 3.65rem 0;
 }
 
 .sectionSoft {
-  background: var(--site-soft-surface);
+  background: #f2f5fa;
   border-top: 1px solid var(--site-border);
   border-bottom: 1px solid var(--site-border);
 }
 
 .sectionInk {
-  background: var(--site-soft-surface);
+  background: #f2f5fa;
   color: var(--ifm-color-content);
   border-top: 1px solid var(--site-border);
   border-bottom: 1px solid var(--site-border);
@@ -105,20 +166,20 @@
 
 .sectionHeader {
   max-width: 42rem;
-  margin-bottom: 1.2rem;
+  margin-bottom: 1.45rem;
 }
 
 .sectionHeader h2 {
   margin-bottom: 0;
-  font-size: clamp(1.7rem, 3.4vw, 2.35rem);
-  line-height: 1.18;
+  font-size: clamp(2.1rem, 4vw, 3rem);
+  line-height: 1.08;
 }
 
 .personaGrid,
 .flowGrid,
 .migrationGrid {
   display: grid;
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .personaGrid {
@@ -135,9 +196,9 @@
 .migrationCard,
 .quoteCard {
   border: 1px solid var(--site-border);
-  border-radius: 10px;
+  border-radius: 18px;
   background: var(--site-surface);
-  padding: 1.1rem;
+  padding: 1.2rem;
   box-shadow: none;
 }
 
@@ -156,10 +217,10 @@
 .inlineCode {
   display: block;
   margin: 0 0 1rem;
-  padding: 0.7rem 0.8rem;
-  border: 1px solid var(--site-border);
-  border-radius: 8px;
-  background: var(--site-inline-code-surface);
+  padding: 0.75rem 0.85rem;
+  border: 1px solid #c5d5ea;
+  border-radius: 12px;
+  background: #ebf2fb;
   color: var(--ifm-color-content);
   overflow-x: auto;
 }
@@ -174,12 +235,12 @@
 .quoteGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .quoteCard {
   margin: 0;
-  border-color: var(--site-border);
+  border-color: #c9d2de;
   background: var(--site-surface);
   box-shadow: none;
 }
@@ -189,7 +250,7 @@
 }
 
 .quoteCard footer {
-  margin-top: 1rem;
+  margin-top: 1.05rem;
   display: flex;
   flex-direction: column;
   gap: 0.15rem;
@@ -198,7 +259,7 @@
 
 @media (max-width: 996px) {
   .heroBanner {
-    padding: 2.6rem 0 2.2rem;
+    padding: 3.1rem 0 2.5rem;
   }
 
   .heroLayout,


### PR DESCRIPTION
## Summary
- restore a homepage style close to the prior version shown in your screenshot
- keep the palette strictly cool blue/gray (no warm/brown accents)
- bring back the stronger hero presentation with subtle grid texture and terminal-style quickstart panel

## Testing
- npm --prefix prototypes/docusaurus run build (passes, with existing broken anchor warning in tutorial docs)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only CSS tweaks to the Docusaurus prototype (no logic, data, or security changes); main risk is unintended layout/contrast regressions across breakpoints/themes.
> 
> **Overview**
> Restyles the Docusaurus prototype homepage toward a cooler blue/gray look, with a stronger hero presentation (grid-textured background, larger typography, and a terminal-style `heroPanel` header treatment).
> 
> Updates component styling across the landing page (cards, sections, inline code blocks, quickstart steps) with larger radii, adjusted spacing, and blue-accented borders/backgrounds, and rounds global `.button` corners more aggressively.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69365ec184e29a30b9f7308e4b8f8ac81ef5a0d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->