### PR TITLE
Fix missing syntax highlighting in code blocks

### DIFF
--- a/prototypes/docusaurus/docusaurus.config.ts
+++ b/prototypes/docusaurus/docusaurus.config.ts
@@ -148,7 +148,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.vsDark,
-      additionalLanguages: ['ruby', 'markup-templating', 'erb', 'diff', 'haml', 'bash'],
+      additionalLanguages: ['ruby', 'markup-templating', 'erb', 'diff', 'haml', 'bash', 'regex', 'ignore'],
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/scripts/prepare-docs.mjs
+++ b/scripts/prepare-docs.mjs
@@ -472,7 +472,7 @@ const languageRemapping = {
   procfile: "yaml",
   Procfile: "yaml",
   "Procfile.dev": "yaml",
-  gitignore: "text",
+  gitignore: "ignore",
   JSON: "json"
 };
 
@@ -485,7 +485,7 @@ function detectCodeLanguage(content) {
   if (/^(yarn |npm |npx |bundle exec |rails |bin\/)/.test(firstLine)) return "bash";
   if (/^[A-Z_]+=\S+$/.test(firstLine.trim()) && lines.length <= 2) return "bash";
 
-  if (/\b(const |let |var |require\(|module\.exports|import )\b/.test(content)) return "js";
+  if (/\b(const |let |var |require\(|module\.exports|import )/.test(content)) return "js";
 
   return "text";
 }


### PR DESCRIPTION
## Summary

- Add `additionalLanguages` (`ruby`, `markup-templating`, `erb`, `diff`, `haml`, `bash`) to the Prism config in `docusaurus.config.ts` — Ruby and ERB blocks were properly labeled but never highlighted because prism-react-renderer doesn't include these grammars by default
- Add a `normalizeCodeFences` step to `prepare-docs.mjs` that labels 53 unlabeled code blocks and remaps 6 invalid language IDs (`rsc`, `procfile`, `Procfile`, `Procfile.dev`, `gitignore`, `JSON`) to valid Prism languages

## Test plan

- [x] `npm run prepare:docs` succeeds, reports "Normalized code fences in 29 files"
- [x] `npm run build` succeeds with no Prism/tokenize errors
- [x] Zero unlabeled code blocks remain after prepare step
- [ ] Verify Ruby, ERB, and Bash code blocks render with proper syntax colors in both light and dark modes

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-build change that only affects generated Docusaurus markdown and syntax highlighting, though the new code-fence normalization could mislabel some blocks if heuristics are wrong.
> 
> **Overview**
> Fixes missing syntax highlighting in Docusaurus by enabling additional Prism grammars (including `ruby`, `erb`, `bash`, `diff`, `haml`, `regex`, `ignore`).
> 
> Updates `prepare-docs.mjs` to normalize markdown code fences during the docs prep step: it remaps a handful of non-Prism language IDs (e.g., `procfile`, `gitignore`, `JSON`) and adds a best-effort language to unlabeled fences based on simple content detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0606a021d7378a5f5fdeac953cd6682118a80732. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced syntax highlighting for code blocks with expanded language support including Ruby, Bash, ERB, Diff, Haml, and more.
  * Improved code block presentation through automatic language detection and normalization in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->