### PR TITLE
Shorten ‘Choose your situation’ subheading

### DIFF
--- a/prototypes/docusaurus/src/pages/index.tsx
+++ b/prototypes/docusaurus/src/pages/index.tsx
@@ -210,7 +210,7 @@ function PersonaSection() {
       <div className="container">
         <div className={styles.sectionHeader}>
           <p className={styles.sectionEyebrow}>Choose your situation</p>
-          <h2>Docs should start from your situation, not from our internal file layout.</h2>
+          <h2>Start where you are.</h2>
         </div>
         <div className={styles.personaGrid}>
           {personaPaths.map((persona) => (


### PR DESCRIPTION
## Summary
- shorten the line under `Choose your situation`
- new text: `Start where you are.`

## Why
- the previous sentence was too long and repeated the same idea as the heading

## Testing
- copy-only change, no behavior changes
- local `npm --prefix prototypes/docusaurus run build` still fails in this environment due missing `@easyops-cn/docusaurus-search-local` (known local dependency mismatch)
