### PR TITLE
Sync address-review commands and add AGENTS.md/CLAUDE.md

### DIFF
--- a/.agents/workflows/address-review.md
+++ b/.agents/workflows/address-review.md
@@ -1,0 +1,126 @@
+# Address Review Prompt
+
+Use this prompt in Codex CLI, ChatGPT, or another coding assistant when you want the equivalent of Claude Code's `/address-review` workflow.
+
+## How to Use
+
+Paste the prompt below into your coding assistant and replace `{{PR_REFERENCE}}` with one of:
+
+- A PR number, such as `12345`
+- A PR URL, such as `https://github.com/org/repo/pull/12345`
+- A specific review URL, such as `https://github.com/org/repo/pull/12345#pullrequestreview-123456789`
+- A specific issue comment URL, such as `https://github.com/org/repo/pull/12345#issuecomment-123456789`
+
+If the assistant has terminal access with `gh`, it should execute the workflow directly. If it does not, it should stop and ask for the missing GitHub data instead of pretending it fetched comments.
+
+## Prompt
+
+```text
+Act as a pull request review triage assistant.
+
+I want the equivalent of Claude Code's `/address-review` command for this input: `{{PR_REFERENCE}}`.
+
+Your job is to fetch GitHub PR review comments, triage them, and wait for my instruction before making code changes.
+
+Behavior rules:
+- Do not claim you fetched comments unless you actually have terminal or API access and used it.
+- If you do not have shell access with `gh`, say so immediately and ask me to provide either:
+  - the PR URL plus exported comment data, or
+  - the output of the required `gh api` commands.
+- Do not auto-fix everything. Stop after triage and wait for my selection.
+- Default to real issues only, not optional polish.
+- After selected items are addressed, reply to the original GitHub comments and resolve threads when appropriate.
+
+Execution flow when terminal access is available:
+
+1. Parse the input:
+   - Support:
+     - PR number only
+     - PR URL
+     - Specific review URL with `#pullrequestreview-...`
+     - Specific issue comment URL with `#issuecomment-...`
+   - If the input is a full GitHub URL, extract the URL's `org/repo` before running `gh repo view`.
+   - Extract the PR number and optional review/comment ID.
+
+2. Determine repository:
+   - If step 1 extracted `org/repo` from a full GitHub URL, use that as `REPO`.
+   - Otherwise run: `REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)`
+   - If `gh` is unavailable or unauthenticated, stop and tell me to fix that first.
+
+3. Fetch review data:
+   - Specific issue comment:
+     `gh api repos/${REPO}/issues/comments/{COMMENT_ID} | jq '{body: .body, user: .user.login, html_url: .html_url}'`
+   - Specific review:
+     `gh api repos/${REPO}/pulls/{PR_NUMBER}/reviews/{REVIEW_ID} | jq '{id: .id, body: .body, state: .state, user: .user.login, html_url: .html_url}'`
+     `gh api --paginate repos/${REPO}/pulls/{PR_NUMBER}/reviews/{REVIEW_ID}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id}]'`
+   - If the review body contains actionable feedback, include it as an additional general comment. Review summary bodies cannot use the `/replies` endpoint; post those responses as general PR comments (see step 7).
+   - Full PR:
+     `gh api --paginate repos/${REPO}/pulls/{PR_NUMBER}/reviews | jq -s '[.[].[] | select((.body // "") != "") | {id: .id, type: "review_summary", body: .body, state: .state, user: .user.login, html_url: .html_url}]'`
+     `gh api --paginate repos/${REPO}/pulls/{PR_NUMBER}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, type: "review", path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id}]'`
+     `gh api --paginate repos/${REPO}/issues/{PR_NUMBER}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, type: "issue", body: .body, user: .user.login, html_url: .html_url}]'`
+   - Include actionable review summary bodies from `/pulls/{PR_NUMBER}/reviews` as additional general comments. Like specific review bodies, they cannot use the `/replies` endpoint and must be answered as general PR comments (see step 7).
+   - For all review-comment paths, fetch thread metadata and match `thread_id` by `node_id`:
+     `OWNER=${REPO%/*}`
+     `NAME=${REPO#*/}`
+     `gh api graphql --paginate -f owner="${OWNER}" -f name="${NAME}" -F pr={PR_NUMBER} -f query='query($owner:String!, $name:String!, $pr:Int!, $endCursor:String) { repository(owner:$owner, name:$name) { pullRequest(number:$pr) { reviewThreads(first:100, after:$endCursor) { nodes { id isResolved comments(first:100) { nodes { id databaseId } } } pageInfo { hasNextPage endCursor } } } } }' | jq -s '[.[].data.repository.pullRequest.reviewThreads.nodes[] | {thread_id: .id, is_resolved: .isResolved, comments: [.comments.nodes[] | {node_id: .id, id: .databaseId}]}]'`
+
+4. Filter comments:
+   - Skip resolved threads.
+   - Do not create standalone triage items from comments where `in_reply_to_id` is set, but use reply text as the latest thread context when it updates or narrows the unresolved concern.
+   - Keep bot comments by default, but deduplicate duplicates and skip status-only bot posts.
+   - Focus on correctness bugs, regressions, security issues, missing tests that hide bugs, and clear adjacent-code inconsistencies.
+   - Skip style nits, speculative suggestions, documentation nits, changelog wording, duplicate comments, and "could consider" feedback unless I ask for polish work.
+   - If the API returns 404, tell me the PR or comment does not exist.
+   - If the API returns 403, tell me to check `gh auth status`.
+   - If nothing is returned, tell me no review comments were found.
+
+5. Triage every remaining comment:
+   - `MUST-FIX`: correctness bugs, regressions, security issues, missing tests that could hide a bug, and clear inconsistencies with adjacent code that would likely block merge.
+   - `DISCUSS`: reasonable scope-expanding suggestions, architectural opinions, and comments that need a decision.
+   - `SKIPPED`: style preferences, documentation nits, comment requests, test-shape preferences, speculative suggestions, changelog wording, duplicate comments, status posts, non-actionable summaries, and factually incorrect suggestions.
+   - Deduplicate overlapping comments before classifying them.
+   - Verify reviewer claims locally before calling something `MUST-FIX`.
+   - If a claim is wrong, classify it as `SKIPPED` and say why.
+   - Preserve comment IDs and thread IDs for later replies and thread resolution.
+   - Treat actionable review summary bodies as normal feedback to classify (`MUST-FIX`/`DISCUSS` as appropriate); skip only boilerplate or status-only summaries.
+   - Track only `MUST-FIX` items as your working checklist.
+   - Use one checklist entry per must-fix item or deduplicated issue.
+   - Use the subject format: `"{file}:{line} - {comment_summary} (@{username})"`.
+   - For general comments, extract the must-fix action from the body.
+
+6. Present triage and wait:
+   - Use a single numbering sequence across all categories.
+   - Show counts for `MUST-FIX`, `DISCUSS`, and `SKIPPED`.
+   - Ask which items I want addressed.
+   - If there are skipped or declined discuss items, also ask which ones should receive rationale replies.
+   - Do not edit code yet.
+
+7. After I choose items:
+   - Address the selected items in code, tests, or docs.
+   - Run relevant checks when possible.
+   - If the user selects `DISCUSS` items to address, treat them the same as `MUST-FIX`: make the change, reply, and resolve the thread.
+   - If the user selects `SKIPPED` or declined `DISCUSS` items for rationale replies, post the rationale reply without making code changes. Resolve those threads only with explicit user approval.
+   - Reply to each addressed review comment:
+     - Issue comments: `gh api repos/${REPO}/issues/{PR_NUMBER}/comments -X POST -f body="<response>"`
+     - Review comment replies: `gh api repos/${REPO}/pulls/{PR_NUMBER}/comments/{COMMENT_ID}/replies -X POST -f body="<response>"`
+     - Review summary body replies: `gh api repos/${REPO}/issues/{PR_NUMBER}/comments -X POST -f body="<response>"`
+   - Resolve threads only when the issue is actually handled or explicitly declined with my approval:
+     `gh api graphql -f query='mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } } }' -f threadId="<THREAD_ID>"`
+   - Do not resolve anything still in progress or uncertain.
+
+Output format for the triage:
+
+MUST-FIX (count):
+1. item
+
+DISCUSS (count):
+2. item
+   Reason: short explanation
+
+SKIPPED (count):
+3. item - short reason
+
+Then ask:
+- Which items should I address?
+- Optional: which skipped or declined items should get rationale replies?
+```

--- a/.claude/commands/address-review.md
+++ b/.claude/commands/address-review.md
@@ -8,6 +8,9 @@ Fetch review comments from a GitHub PR in this repository, triage them, and crea
 
 ## Step 1: Determine the Repository
 
+If the user input is a full GitHub URL, extract `org/repo` from the URL and use that as `REPO`.
+Otherwise, detect the repository from the current checkout:
+
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 ```
@@ -16,7 +19,9 @@ If this command fails, ensure `gh` CLI is installed and authenticated (`gh auth 
 
 ## Step 2: Parse User Input
 
-Extract the PR number and optional review/comment ID from the user's message:
+The user's input is: $ARGUMENTS
+
+Extract the PR number and optional review/comment ID from the input above:
 
 **Supported formats:**
 
@@ -42,21 +47,45 @@ gh api repos/${REPO}/issues/comments/{COMMENT_ID} | jq '{body: .body, user: .use
 **If a specific review ID is provided (`#pullrequestreview-...`):**
 
 ```bash
-gh api repos/${REPO}/pulls/{PR_NUMBER}/reviews/{REVIEW_ID}/comments | jq '[.[] | {id: .id, path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login}]'
+# Review body (often contains summary feedback)
+gh api repos/${REPO}/pulls/{PR_NUMBER}/reviews/{REVIEW_ID} | jq '{id: .id, body: .body, state: .state, user: .user.login, html_url: .html_url}'
+
+# Inline comments for this review
+gh api --paginate repos/${REPO}/pulls/{PR_NUMBER}/reviews/{REVIEW_ID}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id}]'
 ```
 
-**If only PR number is provided (fetch all PR review comments):**
+Include the review body as a general comment when it contains actionable feedback. When the review body contains actionable feedback, note that it cannot be replied to via the `/replies` endpoint — responses to review summary bodies must be posted as general PR comments (see Step 7).
+
+**If only PR number is provided (fetch all PR comments):**
 
 ```bash
-gh api repos/${REPO}/pulls/{PR_NUMBER}/comments | jq '[.[] | {id: .id, path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id}]'
+# Review summary bodies (can contain actionable feedback even without inline comments)
+gh api --paginate repos/${REPO}/pulls/{PR_NUMBER}/reviews | jq -s '[.[].[] | select((.body // "") != "") | {id: .id, type: "review_summary", body: .body, state: .state, user: .user.login, html_url: .html_url}]'
+
+# Inline code review comments
+gh api --paginate repos/${REPO}/pulls/{PR_NUMBER}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, type: "review", path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id}]'
+
+# General PR discussion comments (not tied to specific lines)
+gh api --paginate repos/${REPO}/issues/{PR_NUMBER}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, type: "issue", body: .body, user: .user.login, html_url: .html_url}]'
+```
+
+Include actionable review summary bodies from `/pulls/{PR_NUMBER}/reviews` as additional general comments. Like specific review bodies, they cannot be replied to via the `/replies` endpoint and must be answered as general PR comments (see Step 7).
+
+**For all paths that fetch review comments (both specific review and full PR), fetch review thread metadata and attach `thread_id` by matching each review comment's `node_id`:**
+
+```bash
+OWNER=${REPO%/*}
+NAME=${REPO#*/}
+gh api graphql --paginate -f owner="${OWNER}" -f name="${NAME}" -F pr={PR_NUMBER} -f query='query($owner:String!, $name:String!, $pr:Int!, $endCursor:String) { repository(owner:$owner, name:$name) { pullRequest(number:$pr) { reviewThreads(first:100, after:$endCursor) { nodes { id isResolved comments(first:100) { nodes { id databaseId } } } pageInfo { hasNextPage endCursor } } } } }' | jq -s '[.[].data.repository.pullRequest.reviewThreads.nodes[] | {thread_id: .id, is_resolved: .isResolved, comments: [.comments.nodes[] | {node_id: .id, id: .databaseId}]}]'
 ```
 
 **Filtering comments:**
 
-- Skip comments where `in_reply_to_id` is set (these are replies, not top-level comments)
+- Skip comments belonging to already-resolved threads (match via `thread_id` and `is_resolved` from the GraphQL response)
+- Do not create standalone triage items from comments where `in_reply_to_id` is set, but use reply text as the latest thread context when it updates or narrows the unresolved concern
 - Do not skip bot-generated comments by default. Many actionable review comments in this repository come from bots.
 - Deduplicate repeated bot comments and skip bot status posts, summaries, and acknowledgments that do not require a code or documentation change
-- Treat as actionable by default only: correctness bugs, regressions, missing tests, and clear inconsistencies with adjacent code
+- Treat as actionable by default only: correctness bugs, regressions, security issues, missing tests, and clear inconsistencies with adjacent code
 - Treat as non-actionable by default: style nits, speculative suggestions, changelog wording, duplicate bot comments, and "could consider" feedback unless the user explicitly asks for polish work
 - Focus on actionable feedback, not acknowledgments or thank-you messages
 
@@ -72,7 +101,7 @@ Before creating any todos, classify every review comment into one of three categ
 
 - `MUST-FIX`: correctness bugs, regressions, security issues, missing tests that could hide a real bug, and clear inconsistencies with adjacent code that would likely block merge
 - `DISCUSS`: reasonable suggestions that expand scope, architectural opinions that are not clearly right or wrong, and comments where the reviewer claim may be correct but needs a user decision
-- `SKIPPED`: style preferences, documentation nits, comment requests, test-shape preferences, speculative suggestions, changelog wording, duplicate comments, status posts, summaries, and factually incorrect suggestions
+- `SKIPPED`: style preferences, documentation nits, comment requests, test-shape preferences, speculative suggestions, changelog wording, duplicate comments, status posts, non-actionable summaries, and factually incorrect suggestions
 
 Triage rules:
 
@@ -80,31 +109,38 @@ Triage rules:
 - Verify factual claims locally before classifying a comment as `MUST-FIX`.
 - If a claim appears wrong, classify it as `SKIPPED` and note briefly why.
 - Preserve the original review comment ID and thread ID when available so the command can reply to the correct place and resolve the correct thread later.
+- Treat actionable review summary bodies as normal feedback to classify (`MUST-FIX`/`DISCUSS` as appropriate); skip only boilerplate or status-only summaries.
 
 ## Step 5: Create Todo List
 
-Create a todo list with TodoWrite containing **only the `MUST-FIX` items**:
+Create a task list with TodoWrite containing **only the `MUST-FIX` items**:
 
-- One todo per must-fix comment or deduplicated issue
-- For file-specific comments: `"{file}:{line} - {comment_summary} (@{username})"` (content)
-- For general comments: Parse the comment body and extract the must-fix action
-- Format activeForm: `"Addressing {brief description}"`
-- All todos should start with status: `"pending"`
+- One task per must-fix comment or deduplicated issue
+- Subject: `"{file}:{line} - {comment_summary} (@{username})"`
+- For general comments: Parse the comment body and extract the must-fix action as the subject
+- Description: Include the full review comment text and any relevant context
+- All tasks should start with status: `"pending"`
 
 ## Step 6: Present Triage to User
 
 Present the triage to the user - **DO NOT automatically start addressing items**:
 
-- Number all items sequentially across categories so users can reference any item by number
+- Use a single sequential numbering across all categories (1, 2, 3, ...) so every item has a unique number the user can reference. Do not restart numbering at 1 for each category.
 - `MUST-FIX ({count})`: list the todos created
 - `DISCUSS ({count})`: list items needing user choice, with a short reason
 - `SKIPPED ({count})`: list skipped comments with a short reason, including duplicates and factually incorrect suggestions
 - Wait for the user to tell you which items to address
-- If useful, suggest replying with a brief rationale on declined items, but do not do so unless the user asks
+- Always offer an explicit optional follow-up to post rationale replies on selected `SKIPPED` or declined `DISCUSS` items
+- Never post those rationale replies unless the user explicitly selects which items to reply to
+- Ask two things when there are `SKIPPED` or declined `DISCUSS` items:
+  - Which items to address in code/tests/docs
+  - Which skipped/declined items (if any) should receive a rationale reply
 
 ## Step 7: Address Items, Reply, and Resolve
 
-When addressing items, after completing each selected todo item, reply to the original review comment explaining how it was addressed.
+When addressing items, after completing each selected item (whether `MUST-FIX` or `DISCUSS`), reply to the original review comment explaining how it was addressed.
+If the user selects `DISCUSS` items to address, treat them the same as `MUST-FIX`: make the code change, reply, and resolve the thread.
+If the user selects skipped/declined items for rationale replies, post those replies too.
 
 **For issue comments (general PR comments):**
 
@@ -118,13 +154,15 @@ gh api repos/${REPO}/issues/{PR_NUMBER}/comments -X POST -f body="<response>"
 gh api repos/${REPO}/pulls/{PR_NUMBER}/comments/{COMMENT_ID}/replies -X POST -f body="<response>"
 ```
 
-**For standalone review comments (not in a thread):**
+Use the `/replies` endpoint for all existing review comments, including standalone top-level comments.
+
+**For review summary bodies (from `/pulls/{PR_NUMBER}/reviews/{REVIEW_ID}`):**
+
+Review summary bodies do not have a `comment_id` and cannot be replied to via the `/replies` endpoint. Instead, post a general PR comment referencing the review:
 
 ```bash
-gh api repos/${REPO}/pulls/{PR_NUMBER}/comments -X POST -f body="<response>" -f commit_id="<COMMIT_SHA>" -f path="<FILE_PATH>" -f line=<LINE_NUMBER> -f side="RIGHT"
+gh api repos/${REPO}/issues/{PR_NUMBER}/comments -X POST -f body="<response>"
 ```
-
-Note: `side` is required when using `line`. Use `"RIGHT"` for the PR commit side (most common) or `"LEFT"` for the base commit side.
 
 The response should briefly explain:
 
@@ -177,7 +215,10 @@ SKIPPED (3):
 5. spec/helper_spec.rb:20 - "Consolidate assertions" (@claude[bot]) - test style preference
 
 Which items would you like me to address? (e.g., "1", "1,2", or "all must-fix")
+Optional: I can also post rationale replies for skipped/declined items (e.g., "reply 3,5" or "reply all skipped").
 ```
+
+Note: Only show the "Optional: rationale replies" line when there are `SKIPPED` or declined `DISCUSS` items. Omit it when every item is `MUST-FIX`.
 
 # Important Notes
 
@@ -189,6 +230,7 @@ Which items would you like me to address? (e.g., "1", "1,2", or "all must-fix")
 - **NEVER automatically address all review comments** - always wait for user direction
 - When given a specific review URL, no need to ask for more information
 - **ALWAYS reply to comments after addressing them** to close the feedback loop
+- After triage, always offer to post rationale replies for selected `SKIPPED`/declined items, but only post them with explicit user approval
 - Resolve the review thread after replying when the concern is actually addressed and a thread ID is available
 - Default to real issues only. Do not spend a review cycle on optional polish unless the user explicitly asks for it
 - Triage comments before creating todos. Only `MUST-FIX` items should become todos by default
@@ -198,3 +240,4 @@ Which items would you like me to address? (e.g., "1", "1,2", or "all must-fix")
 
 - Rate limiting: GitHub API has rate limits; if you hit them, wait a few minutes
 - Private repos: Requires appropriate `gh` authentication scope
+- GraphQL inner pagination: The `comments(first:100)` inside each review thread is hardcoded. Threads with >100 comments (rare) will have older comments truncated. The outer `reviewThreads` pagination is handled by `--paginate`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,122 @@
+# AGENTS.md
+
+Instructions for AI coding agents working on the reactonrails.com documentation site.
+
+This is a Docusaurus site that publishes documentation for [React on Rails](https://github.com/shakacode/react_on_rails). Canonical docs live in the `react_on_rails` monorepo (`docs/`); this repo fetches them at build time, transforms them for Docusaurus, and deploys to Cloudflare Pages.
+
+## Reusable Workflows
+
+- `AGENTS.md`: canonical entry point for agent instructions and workflow discovery
+- `.claude/commands/`: Claude Code slash commands
+- `.agents/workflows/`: shared prompt templates and reusable workflows for Codex, GPT, and other non-Claude tools
+- When the user asks to address PR review comments outside Claude slash commands, follow `.agents/workflows/address-review.md`
+
+## Canonical Agent Policy
+
+`AGENTS.md` is the canonical source for repository-wide agent rules:
+
+- Commands and build workflow
+- Code style and formatting expectations
+- Git/PR boundaries and safety rules
+- Project structure
+
+Other agent-facing docs (for example `CLAUDE.md`) should contain only tool-specific workflow notes and link back here.
+If there is a conflict, `AGENTS.md` wins.
+
+## Commands
+
+```bash
+# Sync docs from react_on_rails monorepo
+npm run sync:docs                    # Full sync
+npm run sync:docs:subset             # Subset sync (faster for dev)
+
+# Prepare docs for Docusaurus
+npm run prepare:docs                 # Full prepare
+npm run prepare:docs:subset          # Subset prepare
+
+# Full prepare pipeline
+npm run prepare                      # sync + prepare
+npm run prepare:subset               # sync:subset + prepare:subset
+
+# Install Docusaurus dependencies
+npm run install:site
+
+# Development server
+npm run dev                          # Start Docusaurus dev server
+
+# Build
+npm run build                        # Build Docusaurus site
+npm run build:full                   # prepare + build (end-to-end)
+
+# Deploy
+npm run cloudflare:deploy            # Full build + deploy to Cloudflare Pages
+```
+
+## Project Structure
+
+| Path                          | Purpose                                                  |
+| ----------------------------- | -------------------------------------------------------- |
+| `scripts/`                    | Build scripts (sync-docs, prepare-docs)                  |
+| `prototypes/docusaurus/`      | Docusaurus site (config, theme, static assets)           |
+| `prototypes/docusaurus/docs/` | Generated docs directory (gitignored, built from sync)   |
+| `content/upstream/docs/`      | Synced upstream docs (gitignored)                        |
+| `.github/workflows/`          | CI/CD (site build and deploy)                            |
+| `.claude/commands/`           | Claude Code slash commands                               |
+| `.agents/workflows/`          | Shared prompt templates for non-Claude tools             |
+
+## Content Flow
+
+```
+react_on_rails/docs  -->  content/upstream/docs  -->  prototypes/docusaurus/docs  -->  build/deploy
+```
+
+1. `npm run sync:docs` copies docs from the monorepo into `content/upstream/docs`
+2. `npm run prepare:docs` hydrates the Docusaurus docs directory
+3. Docusaurus builds static output at `prototypes/docusaurus/build`
+4. Cloudflare Pages deploys the static output
+
+## Code Style
+
+- Use `npm` for all operations (not `pnpm` or `yarn`)
+- Ensure all files end with a newline
+- Follow existing patterns in scripts and configuration
+
+## Git Workflow
+
+**Branch naming**: `type/descriptive-name` (e.g., `fix/docs-nav-ordering`)
+
+**Commit messages**: Explain why, not what. One logical change per commit.
+
+**PR creation**: Use `gh pr create` with a clear title, summary, and test plan.
+
+## Review Workflow
+
+- Use at most one AI reviewer that leaves inline comments
+- Wait for the first full review pass to finish before pushing follow-up commits
+- Batch review fixes into one follow-up push when practical
+- Treat as blocking only: correctness bugs, broken builds, regressions, and clear inconsistencies
+- Verify claims locally before changing code in response to AI review comments
+- Deduplicate repeated bot comments before acting on them
+- When asking an agent to address review comments, instruct it to classify comments into `blocking`, `optional`, and `noise`, then apply only the `blocking` items plus any explicitly selected optional items
+
+## Boundaries
+
+### Always
+
+- Test builds locally before pushing (`npm run build`)
+- Ensure all files end with a newline
+- Use `npm` for all operations
+
+### Ask First
+
+- Destructive git operations (force push, reset --hard, branch deletion)
+- Changes to CI workflows (`.github/workflows/`)
+- Changes to build scripts (`scripts/`)
+- Changes to Docusaurus configuration (`prototypes/docusaurus/docusaurus.config.ts`)
+
+### Never
+
+- Skip pre-commit hooks (`--no-verify`)
+- Commit secrets, credentials, or `.env` files
+- Edit synced docs directly in `content/upstream/docs/` or `prototypes/docusaurus/docs/` (these are gitignored and regenerated)
+- Force push to `main`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# CLAUDE.md
+
+Tool-specific guidance for Claude Code in this repository.
+
+## Source of Truth
+
+`AGENTS.md` is the canonical policy for:
+
+- Commands and build workflow
+- Code style and formatting expectations
+- Git/PR boundaries and safety rules
+- Project structure
+
+If this file conflicts with `AGENTS.md`, follow `AGENTS.md`.
+
+## Behavioral Defaults
+
+- When confident in your changes, **commit and push without asking for permission**. Always monitor CI after pushing.
+
+## Git Safety
+
+- **NEVER force-push** (`--force`, `--force-with-lease`) unless the user explicitly requests it. Force-pushing destroys commit history that may represent significant prior work.
+- **NEVER `git reset --hard`** on a branch that has existing commits (yours or others'). This destroys work.
+- When you need to start fresh or test something without affecting an existing branch, **use a git worktree** (`git worktree add`) or **create a new branch** instead of resetting the current one.
+- If a rebase has conflicts, abort and ask the user how to proceed rather than force-pushing a rewritten history.


### PR DESCRIPTION
## Summary

Pulls over the latest address-review command improvements from the react_on_rails repository and establishes agent policy files (AGENTS.md, CLAUDE.md) for this Docusaurus site.

### What changed

- **`.claude/commands/address-review.md`** — Updated to the latest version from [react_on_rails main](https://github.com/shakacode/react_on_rails). Key improvements:
  - `$ARGUMENTS` variable for Claude Code template input
  - `--paginate` on all REST API calls to handle multi-page responses
  - `node_id` / `thread_id` tracking via REST + GraphQL for reliable thread resolution
  - Review summary body fetch and reply path (uses issues endpoint, not `/replies`)
  - General PR discussion comments (issue comments) alongside inline review comments
  - Rationale reply UX — explicitly offers to post rationale replies for skipped/declined items
  - Sequential numbering across all triage categories
  - `comments(first:100)` inner pagination limitation documented
  - Reply context: replies with `in_reply_to_id` used as thread context instead of silently dropped
  - "non-actionable summaries" distinction in SKIPPED category

- **`.agents/workflows/address-review.md`** — New shared prompt for Codex CLI, ChatGPT, Copilot, Cursor, and other non-Claude tools. Mirrors the Claude `/address-review` workflow with behavior rules for assistants that may lack terminal access.

- **`AGENTS.md`** — New canonical agent policy adapted for this Docusaurus site. Includes Reusable Workflows section, project-specific commands, content flow, project structure, review workflow, and boundaries.

- **`CLAUDE.md`** — New Claude-specific guidance that defers to AGENTS.md as the canonical source, with behavioral defaults and git safety rules.

### Source PRs from react_on_rails

These changes incorporate work from the following merged PRs in [shakacode/react_on_rails](https://github.com/shakacode/react_on_rails):

- **[PR #2760](https://github.com/shakacode/react_on_rails/pull/2760)** (merged 2026-03-19) — Synced address-review with triage improvements: `$ARGUMENTS`, review body fetch, `node_id`/`thread_id` tracking, `--paginate` + `jq -s`, GraphQL thread metadata query, known limitations section
- **[PR #2761](https://github.com/shakacode/react_on_rails/pull/2761)** (merged 2026-03-21) — Added `.agents/workflows/address-review.md` shared prompt for non-Claude tools, established the `.agents/workflows/` convention, added "Reusable Workflows" section to AGENTS.md
- **[PR #2798](https://github.com/shakacode/react_on_rails/pull/2798)** (merged 2026-03-21) — Refined triage rules: replies used as thread context instead of dropped, "non-actionable summaries" distinction, all changes applied symmetrically to both Claude and shared prompt files

Earlier foundational PRs:
- **[PR #2555](https://github.com/shakacode/react_on_rails/pull/2555)** (merged 2026-03-08) — Bot comment deduplication, thread resolution via GraphQL, ID preservation through triage
- **[PR #2656](https://github.com/shakacode/react_on_rails/pull/2656)** (merged 2026-03-17) — Sequential numbering across triage categories
- **[PR #2658](https://github.com/shakacode/react_on_rails/pull/2658)** (merged 2026-03-18) — Rationale reply UX improvements
- **[PR #2355](https://github.com/shakacode/react_on_rails/pull/2355)** — Adopted AGENTS.md standard, separated agent policy from user guide
- **[PR #2372](https://github.com/shakacode/react_on_rails/pull/2372)** — Declared AGENTS.md as canonical, refactored CLAUDE.md to defer to it
- **[PR #2557](https://github.com/shakacode/react_on_rails/pull/2557)** (merged 2026-03-08) — Added Review Workflow section to AGENTS.md

### Design decisions

- **Two parallel files**: `.claude/commands/address-review.md` for Claude Code slash commands, `.agents/workflows/address-review.md` for all other tools — following the convention established in react_on_rails PR #2761
- **AGENTS.md is canonical**: All agent tools read AGENTS.md; CLAUDE.md adds only Claude-specific behavioral notes — following the pattern from react_on_rails PR #2372
- **AGENTS.md adapted for Docusaurus**: Commands, project structure, and boundaries are specific to this npm/Docusaurus/Cloudflare Pages project, not copied verbatim from the Ruby gem repo

## Test plan

- [ ] Verify `/address-review` slash command works in Claude Code against a PR in this repo
- [ ] Verify `.agents/workflows/address-review.md` prompt works when pasted into Codex CLI
- [ ] Confirm AGENTS.md and CLAUDE.md are picked up by Claude Code and other agent tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/workflow-only changes affecting AI agent prompts and repo guidance; no runtime code or build logic is modified.
> 
> **Overview**
> Updates the Claude `/address-review` command to a more robust workflow: supports PR/review/comment URLs, paginates GitHub API fetches, includes review summary bodies and general PR comments, maps `node_id` to GraphQL `thread_id` for resolving threads, and refines triage/UX (reply handling, sequential numbering, optional rationale replies).
> 
> Adds a non-Claude equivalent prompt in `.agents/workflows/address-review.md`, and introduces `AGENTS.md` (canonical agent policy for this Docusaurus repo) plus `CLAUDE.md` (Claude-specific guidance that defers to `AGENTS.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c448e166beb4414eb0127f009f7f94b9c351b4b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->