### PR TITLE
Direct pricing CTA to pro.reactonrails.com

### DIFF
--- a/prototypes/docusaurus/src/pages/pro.tsx
+++ b/prototypes/docusaurus/src/pages/pro.tsx
@@ -142,8 +142,8 @@ export default function ProPage(): ReactNode {
             </table>
           </div>
           <p className={styles.note}>
-            Need pricing, implementation guidance, or a free-license discussion? Email{' '}
-            <a href="mailto:justin@shakacode.com">justin@shakacode.com</a>.
+            Need pricing, implementation guidance, or a free-license discussion? Visit{' '}
+            <a href="https://pro.reactonrails.com/">pro.reactonrails.com</a>.
           </p>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- Replace the email CTA ("Email justin@shakacode.com") with a link to [pro.reactonrails.com](https://pro.reactonrails.com/) on the Pro page

## Test plan
- [ ] Verify the link at the bottom of the Pro page points to https://pro.reactonrails.com/
- [ ] Confirm the link text reads "pro.reactonrails.com"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a simple copy/link update on a Docusaurus page with no behavioral, security, or data-handling changes.
> 
> **Overview**
> Updates the React on Rails Pro page CTA under the feature comparison table to **replace the email contact** (`mailto:justin@shakacode.com`) with a **direct link** to `https://pro.reactonrails.com/` for pricing and implementation guidance inquiries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 034782cad9091569bfd0b7447e67f109aa20badc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the contact link for professional services inquiries, directing users to a dedicated website instead of email.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->