### PR TITLE
site: redirect legacy docs guides routes

### DIFF
--- a/prototypes/docusaurus/static/_redirects
+++ b/prototypes/docusaurus/static/_redirects
@@ -1,3 +1,12 @@
+/docs/guides/file-system-based-automated-bundle-generation.md /docs/core-concepts/auto-bundling-file-system-based-automated-bundle-generation/ 301
+/docs/guides/configuration /docs/configuration/ 301
+/docs/guides/configuration/ /docs/configuration/ 301
+/docs/guides/upgrading-react-on-rails /docs/upgrading/upgrading-react-on-rails/ 301
+/docs/guides/upgrading-react-on-rails/ /docs/upgrading/upgrading-react-on-rails/ 301
+/docs/guides/react-server-components-how-it-works /docs/pro/react-server-components/how-react-server-components-work/ 301
+/docs/guides/react-server-components-how-it-works/ /docs/pro/react-server-components/how-react-server-components-work/ 301
+/docs/guides/troubleshooting /docs/deployment/troubleshooting/ 301
+/docs/guides/troubleshooting/ /docs/deployment/troubleshooting/ 301
 /react-on-rails/docs/* /docs/:splat 301
 /react-on-rails/docs /docs 301
 /react-on-rails-pro/docs/* /docs/:splat 301


### PR DESCRIPTION
Fixes #63

## Summary
- add explicit redirects for confirmed legacy `/docs/guides/*` routes that still 404 on reactonrails.com
- keep the change scoped to Cloudflare Pages `_redirects`
- cover the legacy routes verified in the issue plus two additional live 404s that map cleanly to current docs pages

## Test plan
- `npm run prepare && npm run build`
- confirm `prototypes/docusaurus/build/_redirects` contains the new rules
- run `npx --yes wrangler@4.39.0 pages dev prototypes/docusaurus/build --port 8789`
- verify locally that these routes return `301` and then `200`:
  - `/docs/guides/file-system-based-automated-bundle-generation.md`
  - `/docs/guides/configuration/`
  - `/docs/guides/upgrading-react-on-rails`
  - `/docs/guides/react-server-components-how-it-works`
  - `/docs/guides/troubleshooting`

## Notes
- local build still reports pre-existing broken-link warnings unrelated to this redirect change:
  - `/docs/upgrading/changelog.md`
  - `/docs/building-features/streaming-server-rendering#redux-shared-store-caveat`
  - `/docs/pro/installation#node-renderer-installation`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Cloudflare Pages redirect rules and does not change application/runtime code. Main risk is misrouting or redirect loops if a rule is incorrect.
> 
> **Overview**
> Adds explicit `301` redirects in `prototypes/docusaurus/static/_redirects` for several legacy `/docs/guides/*` URLs (including both trailing- and non-trailing-slash variants) to their current docs locations, reducing 404s.
> 
> Keeps the existing broader `/react-on-rails/*` and `/react-on-rails-pro/*` docs redirects unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d410af1a6b9dc4adbec2d6ea988b50e43ae0ecb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documentation structure has been reorganized for improved navigation. Documentation previously under the guides section now redirects to new canonical paths including core concepts, configuration, deployment, and upgrading sections. All legacy documentation URLs remain fully accessible through automatic redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->