### PR TITLE
Convert GitHub alerts to Docusaurus admonitions

### DIFF
--- a/scripts/prepare-docs.mjs
+++ b/scripts/prepare-docs.mjs
@@ -510,9 +510,37 @@ function convertGitHubAlertsInMarkdown(markdown) {
   const lines = markdown.split("\n");
   const result = [];
   let i = 0;
+  let fence = null;
 
   while (i < lines.length) {
-    const alertMatch = lines[i].match(alertPattern);
+    const line = lines[i];
+
+    if (!fence) {
+      const openingFence = line.match(/^\s*(`{3,}|~{3,})/);
+      if (openingFence) {
+        fence = {
+          marker: openingFence[1][0],
+          length: openingFence[1].length,
+        };
+        result.push(line);
+        i++;
+        continue;
+      }
+    } else {
+      result.push(line);
+      const closingFence = line.match(/^\s*(`{3,}|~{3,})\s*$/);
+      if (
+        closingFence &&
+        closingFence[1][0] === fence.marker &&
+        closingFence[1].length >= fence.length
+      ) {
+        fence = null;
+      }
+      i++;
+      continue;
+    }
+
+    const alertMatch = line.match(alertPattern);
     if (alertMatch) {
       const indent = alertMatch[1];
       const admonitionType = githubAlertToDocusaurus[alertMatch[2]];
@@ -537,7 +565,7 @@ function convertGitHubAlertsInMarkdown(markdown) {
       }
       result.push(`${indent}:::`);
     } else {
-      result.push(lines[i]);
+      result.push(line);
       i++;
     }
   }
@@ -718,7 +746,6 @@ async function prepareDocusaurus() {
   await fixKnownDocsIssues(docsRoot);
   await normalizeCodeFences(docsRoot);
   const hasArchive = await archiveLegacyDocs(docsRoot);
-  await convertGitHubAlerts(docsRoot);
   await fs.unlink(path.join(docsRoot, "upgrading", "changelog.md")).catch((error) => {
     if (error?.code !== "ENOENT") {
       throw error;
@@ -730,6 +757,7 @@ async function prepareDocusaurus() {
     docsHomeMarkdown(docsHomeSource, { hasArchive }),
     "utf8"
   );
+  await convertGitHubAlerts(docsRoot);
 
   await prepareSidebars(siteRoot, hasArchive);
 

--- a/scripts/prepare-docs.mjs
+++ b/scripts/prepare-docs.mjs
@@ -514,9 +514,10 @@ function convertGitHubAlertsInMarkdown(markdown) {
 
   while (i < lines.length) {
     const line = lines[i];
+    const normalizedLine = line.replace(/^\s*(?:>\s*)+/, "");
 
     if (!fence) {
-      const openingFence = line.match(/^\s*(`{3,}|~{3,})/);
+      const openingFence = normalizedLine.match(/^\s*(`{3,}|~{3,})/);
       if (openingFence) {
         fence = {
           marker: openingFence[1][0],
@@ -528,7 +529,7 @@ function convertGitHubAlertsInMarkdown(markdown) {
       }
     } else {
       result.push(line);
-      const closingFence = line.match(/^\s*(`{3,}|~{3,})\s*$/);
+      const closingFence = normalizedLine.match(/^\s*(`{3,}|~{3,})\s*$/);
       if (
         closingFence &&
         closingFence[1][0] === fence.marker &&

--- a/scripts/prepare-docs.mjs
+++ b/scripts/prepare-docs.mjs
@@ -474,6 +474,14 @@ async function injectProFriendlyNotice(docsRoot) {
   }
 }
 
+const githubAlertToDocusaurus = {
+  NOTE: "note",
+  TIP: "tip",
+  IMPORTANT: "info",
+  WARNING: "warning",
+  CAUTION: "danger",
+};
+
 const languageRemapping = {
   rsc: "text",
   procfile: "yaml",
@@ -495,6 +503,46 @@ function detectCodeLanguage(content) {
   if (/\b(const |let |var |require\(|module\.exports|import )/.test(content)) return "js";
 
   return "text";
+}
+
+function convertGitHubAlertsInMarkdown(markdown) {
+  const alertPattern = /^(\s*)>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\](.*)$/;
+  const lines = markdown.split("\n");
+  const result = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const alertMatch = lines[i].match(alertPattern);
+    if (alertMatch) {
+      const indent = alertMatch[1];
+      const admonitionType = githubAlertToDocusaurus[alertMatch[2]];
+      const trailing = alertMatch[3].trim();
+      const contentLines = [];
+
+      // Handle inline content after the alert type (e.g., "> [!WARNING] > **Title**")
+      if (trailing) {
+        contentLines.push(trailing.replace(/^>\s*/, ""));
+      }
+
+      i++;
+
+      while (i < lines.length && lines[i].startsWith(`${indent}>`)) {
+        contentLines.push(lines[i].replace(new RegExp(`^${indent}>\\s?`), ""));
+        i++;
+      }
+
+      result.push(`${indent}:::${admonitionType}`);
+      for (const line of contentLines) {
+        result.push(line ? `${indent}${line}` : "");
+      }
+      result.push(`${indent}:::`);
+    } else {
+      result.push(lines[i]);
+      i++;
+    }
+  }
+
+  return result.join("\n");
 }
 
 function normalizeCodeFencesInMarkdown(markdown) {
@@ -531,6 +579,27 @@ function normalizeCodeFencesInMarkdown(markdown) {
   }
 
   return lines.join("\n");
+}
+
+async function convertGitHubAlerts(docsRoot) {
+  let filesUpdated = 0;
+
+  await walkFiles(docsRoot, async (absoluteFile, relativeFile) => {
+    if (!relativeFile.endsWith(".md") && !relativeFile.endsWith(".mdx")) {
+      return;
+    }
+
+    const original = await fs.readFile(absoluteFile, "utf8");
+    const updated = convertGitHubAlertsInMarkdown(original);
+    if (updated !== original) {
+      await fs.writeFile(absoluteFile, updated, "utf8");
+      filesUpdated += 1;
+    }
+  });
+
+  if (filesUpdated > 0) {
+    console.log(`Converted GitHub alerts to Docusaurus admonitions in ${filesUpdated} files`);
+  }
 }
 
 async function normalizeCodeFences(docsRoot) {
@@ -649,6 +718,7 @@ async function prepareDocusaurus() {
   await fixKnownDocsIssues(docsRoot);
   await normalizeCodeFences(docsRoot);
   const hasArchive = await archiveLegacyDocs(docsRoot);
+  await convertGitHubAlerts(docsRoot);
   await fs.unlink(path.join(docsRoot, "upgrading", "changelog.md")).catch((error) => {
     if (error?.code !== "ENOENT") {
       throw error;


### PR DESCRIPTION
## Summary

- Adds a transformation step in `prepare-docs.mjs` that converts GitHub-flavored alert syntax (`> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]`) to Docusaurus `:::` admonition syntax
- Handles edge cases: indented alerts inside list items, and inline content after the alert type declaration
- Runs after `archiveLegacyDocs` so it also converts the `> [!WARNING]` that archiving generates
- Converts 33 files in the current upstream docs

**Mapping:**
| GitHub | Docusaurus |
|--------|-----------|
| `NOTE` | `note` |
| `TIP` | `tip` |
| `IMPORTANT` | `info` |
| `WARNING` | `warning` |
| `CAUTION` | `danger` |

## Why

Upstream docs use `> [!NOTE]` etc. which renders correctly on GitHub but appears as raw text on the Docusaurus site. Rather than banning the syntax upstream (where it renders perfectly), we convert it during the prepare step — consistent with the existing approach of transforming upstream markdown for Docusaurus compatibility.

## Test plan
- [x] `npm run prepare:docs` — converts 33 files, zero raw `[!...]` alerts remain
- [x] `npm run build` — site builds successfully
- [ ] Visual check: verify admonitions render as styled callout boxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time markdown rewriting only; risk is limited to potential formatting edge cases in docs rendering, with no runtime or security impact.
> 
> **Overview**
> Updates `scripts/prepare-docs.mjs` to post-process generated `.md/.mdx` docs and convert GitHub alert blocks (`> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]`) into Docusaurus `:::` admonitions using a defined type mapping.
> 
> The converter preserves indentation (including alerts nested in lists), supports inline trailing content after the alert marker, avoids rewriting inside fenced code blocks, and is run near the end of `prepareDocusaurus` so it also transforms alerts inserted by the legacy-archiving step; it logs how many files were updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb642588cd2a0e0741427e011eb8ccfcaa12d715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Documentation build now auto-converts GitHub-style alert blocks (NOTE/TIP/IMPORTANT/WARNING/CAUTION) into Docusaurus admonitions for consistent rendering.
  * The conversion scans Markdown/MDX files, respects fenced code blocks and indentation, preserves inline marker text, rewrites only changed files, and logs a summary of updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->