### PR TITLE
Add redirects for canonical route cleanup (#75)

### DIFF
--- a/prototypes/docusaurus/docusaurus.config.ts
+++ b/prototypes/docusaurus/docusaurus.config.ts
@@ -143,7 +143,7 @@ const config: Config = {
             {label: 'Create a New App', to: '/docs/getting-started/create-react-on-rails-app'},
             {
               label: 'Install into Existing Rails App',
-              to: '/docs/getting-started/installation-into-an-existing-rails-app',
+              to: '/docs/getting-started/existing-rails-app',
             },
             {label: 'Quick Start', to: '/docs/getting-started/quick-start'},
             {label: 'Compare OSS and Pro', to: '/docs/getting-started/oss-vs-pro'},

--- a/prototypes/docusaurus/src/constants/docsRoutes.ts
+++ b/prototypes/docusaurus/src/constants/docsRoutes.ts
@@ -1,7 +1,7 @@
 export const docsRoutes = {
   docsGuide: '/docs/',
   createApp: '/docs/getting-started/create-react-on-rails-app',
-  installExistingApp: '/docs/getting-started/installation-into-an-existing-rails-app',
+  installExistingApp: '/docs/getting-started/existing-rails-app',
   ossVsPro: '/docs/getting-started/oss-vs-pro',
   proOverview: '/docs/pro',
   proUpgrade: '/docs/pro/upgrading-to-pro',

--- a/prototypes/docusaurus/static/_redirects
+++ b/prototypes/docusaurus/static/_redirects
@@ -1,4 +1,4 @@
-/docs/guides/file-system-based-automated-bundle-generation.md /docs/core-concepts/auto-bundling-file-system-based-automated-bundle-generation/ 301
+/docs/guides/file-system-based-automated-bundle-generation.md /docs/core-concepts/auto-bundling/ 301
 /docs/guides/configuration /docs/configuration/ 301
 /docs/guides/configuration/ /docs/configuration/ 301
 /docs/guides/upgrading-react-on-rails /docs/upgrading/upgrading-react-on-rails/ 301
@@ -23,3 +23,13 @@
 /react-on-rails/docs /docs 301
 /react-on-rails-pro/docs/* /docs/:splat 301
 /react-on-rails-pro/docs /docs 301
+
+# Canonical route cleanup from react_on_rails (see shakacode/react_on_rails#3067)
+/docs/core-concepts/auto-bundling-file-system-based-automated-bundle-generation /docs/core-concepts/auto-bundling/ 301
+/docs/core-concepts/auto-bundling-file-system-based-automated-bundle-generation/ /docs/core-concepts/auto-bundling/ 301
+/docs/getting-started/installation-into-an-existing-rails-app /docs/getting-started/existing-rails-app/ 301
+/docs/getting-started/installation-into-an-existing-rails-app/ /docs/getting-started/existing-rails-app/ 301
+/docs/building-features/how-to-conditionally-server-render-based-on-device-type /docs/building-features/conditional-server-rendering/ 301
+/docs/building-features/how-to-conditionally-server-render-based-on-device-type/ /docs/building-features/conditional-server-rendering/ 301
+/docs/building-features/how-to-use-different-files-for-client-and-server-rendering /docs/building-features/client-server-files/ 301
+/docs/building-features/how-to-use-different-files-for-client-and-server-rendering/ /docs/building-features/client-server-files/ 301


### PR DESCRIPTION
## Summary

Follows [shakacode/react_on_rails#3067](https://github.com/shakacode/react_on_rails/pull/3067), which canonicalized four verbose docs URL slugs via Docusaurus `slug:` frontmatter. This PR wires up the site side so old URLs and site-shell links resolve to the new canonical routes.

### Redirects added (with and without trailing slash)

| Legacy path | Canonical path |
|---|---|
| `/docs/core-concepts/auto-bundling-file-system-based-automated-bundle-generation` | `/docs/core-concepts/auto-bundling/` |
| `/docs/getting-started/installation-into-an-existing-rails-app` | `/docs/getting-started/existing-rails-app/` |
| `/docs/building-features/how-to-conditionally-server-render-based-on-device-type` | `/docs/building-features/conditional-server-rendering/` |
| `/docs/building-features/how-to-use-different-files-for-client-and-server-rendering` | `/docs/building-features/client-server-files/` |

### Other changes

- Point the existing `/docs/guides/file-system-based-automated-bundle-generation.md` redirect directly at `/docs/core-concepts/auto-bundling/` to avoid a redirect chain
- Update site-shell references to the old `installation-into-an-existing-rails-app` slug in `docusaurus.config.ts` (footer) and `docsRoutes.ts` (used by homepage CTAs)

`/docs/pro/` already has redirect coverage from earlier work (#71/#73) and remains the canonical Pro docs destination.

Fixes #75

## Test plan

- [x] `node --test scripts/docs-layout.test.mjs` passes
- [ ] After deploy, verify each legacy URL returns 301 to the canonical destination
- [ ] After deploy, verify homepage footer "Install into Existing Rails App" link resolves without a redirect hop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: docs-site link and redirect updates only; main risk is misrouted/looping redirects if any path is mistyped.
> 
> **Overview**
> Aligns the Docusaurus site shell with newly canonicalized docs slugs by updating the footer and shared `docsRoutes` constant to use `/docs/getting-started/existing-rails-app` instead of the old verbose path.
> 
> Expands `static/_redirects` with 301s (with and without trailing slashes) from several legacy, long-form doc URLs to their shorter canonical routes, and updates an existing redirect to point directly at `/docs/core-concepts/auto-bundling/` to avoid a redirect chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec24802593729c90696fcbb70600e306b8cee7f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified documentation URL routes with shorter, cleaner paths
  * Added automatic redirects from legacy documentation paths to new canonical locations, ensuring existing links continue to work
  * Enhanced URL structure for better navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->