### PR TITLE
[codex] Surface public RSC performance demo

### DIFF
--- a/prototypes/docusaurus/sidebars.ts
+++ b/prototypes/docusaurus/sidebars.ts
@@ -6,6 +6,9 @@ import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
 // - deployment/troubleshooting-when-using-webpacker
 // - misc/asset-pipeline
 //
+// URL-compatibility stubs (redirect to a current, live page):
+// - pro/home-pro (→ pro/react-on-rails-pro)
+//
 // Contributing/Resources pages (linked from introduction.md instead of sidebar):
 // - misc/doctrine
 // - misc/style
@@ -24,6 +27,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         'getting-started/quick-start',
+        'getting-started/examples-and-references',
         'getting-started/create-react-on-rails-app',
         'getting-started/tutorial',
         'getting-started/installation-into-an-existing-rails-app',
@@ -172,6 +176,7 @@ const sidebars: SidebarsConfig = {
           type: 'category',
           label: 'Migration Guides',
           items: [
+            'migrating/example-migrations',
             'migrating/migrating-from-react-rails',
             'migrating/migrating-from-vite-rails',
             'migrating/migrating-from-webpack-to-rspack',
@@ -201,6 +206,7 @@ const sidebars: SidebarsConfig = {
           link: { type: 'doc', id: 'pro/react-server-components/index' },
           items: [
             'pro/react-server-components/purpose-and-benefits',
+            'pro/react-server-components/success-stories',
             'pro/react-server-components/how-react-server-components-work',
             'pro/react-server-components/rendering-flow',
             'pro/react-server-components/tutorial',
@@ -211,6 +217,7 @@ const sidebars: SidebarsConfig = {
             'pro/react-server-components/selective-hydration-in-streamed-components',
             'pro/react-server-components/flight-protocol-syntax',
             'pro/react-server-components/upgrading-existing-pro-app',
+            'pro/react-server-components/rspack-compatibility',
             'pro/react-server-components/glossary',
             {
               type: 'category',
@@ -221,6 +228,7 @@ const sidebars: SidebarsConfig = {
                 'migrating/rsc-component-patterns',
                 'migrating/rsc-context-and-state',
                 'migrating/rsc-data-fetching',
+                'migrating/rsc-http-response-patterns',
                 'migrating/rsc-third-party-libs',
                 'migrating/rsc-troubleshooting',
                 'migrating/rsc-flight-payload',

--- a/prototypes/docusaurus/src/pages/examples.tsx
+++ b/prototypes/docusaurus/src/pages/examples.tsx
@@ -5,13 +5,20 @@ import Layout from '@theme/Layout';
 import {docsRoutes} from '../constants/docsRoutes';
 import styles from './examples.module.css';
 
-const evaluationPaths = [
+type EvaluationPath = {
+  eyebrow: string;
+  title: string;
+  description: string;
+  cta: string;
+} & ({to: string; href?: never} | {href: string; to?: never});
+
+const evaluationPaths: EvaluationPath[] = [
   {
     eyebrow: 'Evaluator path',
     title: 'Compare setup approaches',
     description:
       'Start with the docs landing page to choose between new app setup, existing app install, migration, or Pro evaluation.',
-    href: docsRoutes.docsGuide,
+    to: docsRoutes.docsGuide,
     cta: 'Open the docs guide',
   },
   {
@@ -19,7 +26,7 @@ const evaluationPaths = [
     title: 'Move from react-rails',
     description:
       'Follow a migration sequence validated against a real open-source example app instead of reconstructing it from old guides.',
-    href: docsRoutes.migrateFromReactRails,
+    to: docsRoutes.migrateFromReactRails,
     cta: 'Use the react-rails guide',
   },
   {
@@ -27,7 +34,7 @@ const evaluationPaths = [
     title: 'Move from OSS to Pro',
     description:
       'If your current app needs more SSR throughput or RSC support, compare OSS and Pro before adding the Pro package.',
-    href: docsRoutes.ossVsPro,
+    to: docsRoutes.ossVsPro,
     cta: 'Compare OSS and Pro',
   },
   {
@@ -93,7 +100,10 @@ export default function ExamplesPage(): ReactNode {
                 <p className={styles.cardEyebrow}>{path.eyebrow}</p>
                 <h3>{path.title}</h3>
                 <p>{path.description}</p>
-                <Link className={styles.cardLink} to={path.href}>
+                <Link
+                  className={styles.cardLink}
+                  {...('href' in path ? {href: path.href} : {to: path.to})}
+                >
                   {path.cta}
                 </Link>
               </article>

--- a/prototypes/docusaurus/src/pages/examples.tsx
+++ b/prototypes/docusaurus/src/pages/examples.tsx
@@ -30,6 +30,14 @@ const evaluationPaths = [
     href: docsRoutes.ossVsPro,
     cta: 'Compare OSS and Pro',
   },
+  {
+    eyebrow: 'RSC proof path',
+    title: 'Inspect the RSC performance demo',
+    description:
+      'Open the LocalHub benchmark dashboard with Lighthouse reports, bundle-size evidence, and SSR/client/RSC comparisons.',
+    href: 'https://rsc.reactonrails.com/search-performance',
+    cta: 'Open RSC benchmark',
+  },
 ];
 
 const exampleApps = [
@@ -50,6 +58,12 @@ const exampleApps = [
     description:
       'Official Vite Rails sample app used to document migration preflight and dependency lockfile issues.',
     href: 'https://github.com/ElMassimo/vite_ruby/tree/main/examples/rails',
+  },
+  {
+    title: 'react-on-rails-demo-marketplace-rsc',
+    description:
+      'Public React on Rails Pro + RSC marketplace demo behind the LocalHub Lighthouse and bundle-size comparisons.',
+    href: 'https://github.com/shakacode/react-on-rails-demo-marketplace-rsc',
   },
 ];
 
@@ -90,7 +104,7 @@ export default function ExamplesPage(): ReactNode {
         <section className="container">
           <div className={styles.sectionHeader}>
             <p className={styles.sectionEyebrow}>Reference repos</p>
-            <h2>Open-source apps that map to the docs.</h2>
+            <h2>Public apps and demos that map to the docs.</h2>
           </div>
           <div className={styles.grid}>
             {exampleApps.map((app) => (

--- a/prototypes/docusaurus/src/pages/pro.tsx
+++ b/prototypes/docusaurus/src/pages/pro.tsx
@@ -48,6 +48,11 @@ const featureRows = [
     pro: 'Included',
   },
   {
+    feature: 'Public RSC demo with Lighthouse and bundle evidence',
+    oss: 'View-only',
+    pro: 'Included implementation patterns',
+  },
+  {
     feature: 'Support access with ShakaCode maintainers',
     oss: 'Community channels',
     pro: 'Sponsor support plans',
@@ -75,6 +80,11 @@ export default function ProPage(): ReactNode {
                 className="button button--secondary button--lg"
                 to={docsRoutes.proOverview}>
                 Open Pro docs overview
+              </Link>
+              <Link
+                className="button button--secondary button--lg"
+                href="https://rsc.reactonrails.com/search-performance">
+                View RSC performance demo
               </Link>
               <Link
                 className="button button--secondary button--lg"
@@ -144,7 +154,9 @@ export default function ProPage(): ReactNode {
           </div>
           <p className={styles.note}>
             Need pricing, implementation guidance, or a free-license discussion? Visit{' '}
-            <a href="/docs/pro">the Pro docs landing page</a>.
+            <a href="/docs/pro">the Pro docs landing page</a>. Want proof first?
+            Open the{' '}
+            <a href="https://rsc.reactonrails.com/search-performance">RSC performance dashboard</a>.
           </p>
         </section>
       </main>


### PR DESCRIPTION
## Summary

- Adds prominent reactonrails.com links to the public RSC performance dashboard from the examples and Pro pages.
- Adds the marketplace RSC demo repo to the examples repository list.
- Commits the regenerated Docusaurus sidebar from the latest upstream docs sync.

## Validation

- `npm run build:full` passed.
- `npm --prefix prototypes/docusaurus run typecheck` passed.
- External link probe returned HTTP 200 for the RSC demo homepage, performance dashboard, Lighthouse pages, `/why-rsc`, and marketplace RSC demo repo.

Note: the Docusaurus build still reports existing unrelated broken link/anchor warnings in legacy/upstream docs; none are from the new RSC links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-site updates that add new navigation items and external links; main risk is broken/changed external URLs or minor routing issues.
> 
> **Overview**
> Surfaces a public React Server Components performance dashboard more prominently by adding a new evaluation card on `examples` and a new CTA/button plus comparison-row messaging on the `pro` page.
> 
> Expands the examples list with the public RSC marketplace demo repo, and updates the Docusaurus sidebar to include additional Getting Started/Migration/RSC-related docs entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 602ded388939ed466078da92c753d337a5eaf8c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->