### PR TITLE
[codex] Clarify LocalHub example copy

### DIFF
--- a/prototypes/docusaurus/src/pages/examples.tsx
+++ b/prototypes/docusaurus/src/pages/examples.tsx
@@ -41,7 +41,7 @@ const evaluationPaths: EvaluationPath[] = [
     eyebrow: 'RSC proof path',
     title: 'Inspect the RSC performance demo',
     description:
-      'Open the LocalHub benchmark dashboard with Lighthouse reports, bundle-size evidence, and SSR/client/RSC comparisons.',
+      'Open the benchmark dashboard for LocalHub, the sample marketplace app, with Lighthouse reports, bundle-size evidence, and SSR/client/RSC comparisons.',
     href: 'https://rsc.reactonrails.com/search-performance',
     cta: 'Open RSC benchmark',
   },
@@ -69,7 +69,7 @@ const exampleApps = [
   {
     title: 'react-on-rails-demo-marketplace-rsc',
     description:
-      'Public React on Rails Pro + RSC marketplace demo behind the LocalHub Lighthouse and bundle-size comparisons.',
+      'Public React on Rails Pro + RSC marketplace demo behind the LocalHub sample app Lighthouse and bundle-size comparisons.',
     href: 'https://github.com/shakacode/react-on-rails-demo-marketplace-rsc',
   },
 ];


### PR DESCRIPTION
## Summary

- Clarifies that LocalHub is the sample marketplace app behind the public RSC performance dashboard.
- Updates the examples page copy without changing links or behavior.

## Validation

- `npm --prefix prototypes/docusaurus run typecheck` passed.
- `npm run build:full` passed.

Note: the Docusaurus build still reports the same pre-existing unrelated broken link/anchor warnings in upstream docs; this PR does not add new warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only change on the Docusaurus `Examples` page; no link targets or runtime behavior are modified.
> 
> **Overview**
> Updates `prototypes/docusaurus/src/pages/examples.tsx` text to clarify that **LocalHub is the sample marketplace app** behind the public RSC benchmark dashboard and related Lighthouse/bundle-size comparisons, without changing any routes, links, or page behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cfb1c0dbe96467f310d60544da7e279d6861468. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->