### PR TITLE
Publish changelog as docs page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 content/upstream/docs/
 content/upstream/docs-subset/
 content/upstream/sidebars.ts
+content/upstream/CHANGELOG.md
 prototypes/docusaurus/docs/
 
 .DS_Store

--- a/prototypes/docusaurus/docusaurus.config.ts
+++ b/prototypes/docusaurus/docusaurus.config.ts
@@ -164,7 +164,7 @@ const config: Config = {
             },
             {
               label: 'Changelog',
-              href: 'https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md',
+              to: '/docs/upgrading/changelog',
             },
             {
               label: 'ShakaCode',

--- a/prototypes/docusaurus/docusaurus.config.ts
+++ b/prototypes/docusaurus/docusaurus.config.ts
@@ -163,6 +163,10 @@ const config: Config = {
               href: 'https://github.com/shakacode/react_on_rails/discussions',
             },
             {
+              label: 'Changelog',
+              href: 'https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md',
+            },
+            {
               label: 'ShakaCode',
               href: 'https://www.shakacode.com',
             },

--- a/prototypes/docusaurus/sidebars.ts
+++ b/prototypes/docusaurus/sidebars.ts
@@ -169,7 +169,7 @@ const sidebars: SidebarsConfig = {
         'pro/release-notes/index',
         {
           type: 'link',
-          label: 'Full Changelog',
+          label: 'Full GitHub Changelog',
           href: 'https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md',
         },
         {

--- a/prototypes/docusaurus/sidebars.ts
+++ b/prototypes/docusaurus/sidebars.ts
@@ -167,11 +167,7 @@ const sidebars: SidebarsConfig = {
         'pro/updating',
         'pro/major-performance-breakthroughs-upgrade-guide',
         'pro/release-notes/index',
-        {
-          type: 'link',
-          label: 'Full GitHub Changelog',
-          href: 'https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md',
-        },
+        { type: 'doc', id: 'upgrading/changelog', label: 'Changelog' },
         {
           type: 'category',
           label: 'Migration Guides',
@@ -196,6 +192,7 @@ const sidebars: SidebarsConfig = {
         'pro/upgrading-to-pro',
         'pro/streaming-ssr',
         'pro/node-renderer',
+        'pro/rolling-deploy-adapters',
         'pro/fragment-caching',
         'pro/js-memory-leaks',
         'pro/profiling-server-side-rendering-code',

--- a/scripts/prepare-docs.mjs
+++ b/scripts/prepare-docs.mjs
@@ -671,6 +671,45 @@ export function docsHomeMarkdown(sourceMarkdown, { hasArchive }) {
   return `---\ncustom_edit_url: null\n---\n\n${updated}\n`;
 }
 
+export function changelogMarkdown(sourceMarkdown) {
+  const trimmed = sourceMarkdown.replace(/^﻿/, "").trimStart();
+  // Drop the upstream `# Change Log` (or `# Changelog`) H1; the Docusaurus
+  // page title is supplied by frontmatter. Preserves the rest of the document.
+  const withoutH1 = trimmed.replace(/^#\s+Change\s*log[^\n]*\n+/i, "");
+  // Rewrite relative links that were valid in the source repo layout but
+  // would break inside the published page at /docs/upgrading/changelog.
+  //   docs/oss/<path>.md  → /docs/<path>  (matches the split-layout flatten)
+  //   ./README.md         → upstream README on GitHub
+  //   react_on_rails/spec/dummy → upstream sample app on GitHub
+  const withRewrittenLinks = withoutH1
+    .replace(/\(docs\/oss\/([^)\s]+?)\.md(#[^)]+)?\)/g, "(/docs/$1$2)")
+    .replace(
+      /\]\(\.\/README\.md\)/g,
+      "](https://github.com/shakacode/react_on_rails/blob/main/README.md)"
+    )
+    .replace(
+      /\]\(react_on_rails\/spec\/dummy\)/g,
+      "](https://github.com/shakacode/react_on_rails/tree/main/spec/dummy)"
+    );
+  // `mdx.format: md` opts this page out of MDX so historical entries that
+  // mention raw tags like `<script async>` or `<head>` render as CommonMark
+  // text instead of being parsed as JSX (which would fail the build).
+  const frontmatter = [
+    "---",
+    "id: changelog",
+    "title: Changelog",
+    "description: Release-by-release changelog for React on Rails (open source) and React on Rails Pro.",
+    "sidebar_label: Changelog",
+    "slug: /upgrading/changelog",
+    "mdx:",
+    "  format: md",
+    "custom_edit_url: https://github.com/shakacode/react_on_rails/edit/main/CHANGELOG.md",
+    "---",
+    ""
+  ].join("\n");
+  return `${frontmatter}\n${withRewrittenLinks.trimEnd()}\n`;
+}
+
 function archiveSidebarCategory() {
   const legacyItems = legacyDocsToArchive.map(
     (entry) => `            'archive/legacy/${stripMdExtension(entry.source)}',`
@@ -695,8 +734,8 @@ ${legacyItems.join("\n")}
 
 export function siteSidebarSource(source, { hasArchive }) {
   let content = source.replace(
-    /label: 'Full Changelog',\n(\s*)href: 'https:\/\/github\.com\/shakacode\/react_on_rails\/blob\/main\/CHANGELOG\.md'/,
-    "label: 'Full GitHub Changelog',\n$1href: 'https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md'"
+    /\{\s*type: 'link',\s*label: 'Full Changelog',\s*href: 'https:\/\/github\.com\/shakacode\/react_on_rails\/blob\/main\/CHANGELOG\.md',?\s*\},?/,
+    "{ type: 'doc', id: 'upgrading/changelog', label: 'Changelog' },"
   );
 
   if (hasArchive) {
@@ -709,6 +748,27 @@ export function siteSidebarSource(source, { hasArchive }) {
   }
 
   return content;
+}
+
+async function prepareChangelog(docsRoot) {
+  const targetPath = path.join(docsRoot, "upgrading", "changelog.md");
+  const upstreamChangelog = path.join(workspaceRoot, "content", "upstream", "CHANGELOG.md");
+
+  if (!(await exists(upstreamChangelog))) {
+    console.warn(
+      `Warning: ${upstreamChangelog} not found — skipping changelog publish. Run \`npm run sync:docs\` to fetch it.`
+    );
+    return;
+  }
+
+  const source = await fs.readFile(upstreamChangelog, "utf8");
+  const rendered = changelogMarkdown(source);
+
+  // Overwrite the dangling symlink that was copied from the upstream tree.
+  await fs.rm(targetPath, { force: true });
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  await fs.writeFile(targetPath, rendered, "utf8");
+  console.log(`Generated ${path.relative(workspaceRoot, targetPath)} from upstream CHANGELOG.md`);
 }
 
 async function prepareSidebars(siteRoot, hasArchive) {
@@ -764,11 +824,7 @@ async function prepareDocusaurus() {
   await fixKnownDocsIssues(docsRoot);
   await normalizeCodeFences(docsRoot);
   const hasArchive = await archiveLegacyDocs(docsRoot);
-  await fs.unlink(path.join(docsRoot, "upgrading", "changelog.md")).catch((error) => {
-    if (error?.code !== "ENOENT") {
-      throw error;
-    }
-  });
+  await prepareChangelog(docsRoot);
   const docsHomeSource = await fs.readFile(layoutPaths.readmePath, "utf8");
   await fs.writeFile(
     path.join(docsRoot, "README.md"),

--- a/scripts/prepare-docs.mjs
+++ b/scripts/prepare-docs.mjs
@@ -693,6 +693,24 @@ ${legacyItems.join("\n")}
     },`;
 }
 
+export function siteSidebarSource(source, { hasArchive }) {
+  let content = source.replace(
+    /label: 'Full Changelog',\n(\s*)href: 'https:\/\/github\.com\/shakacode\/react_on_rails\/blob\/main\/CHANGELOG\.md'/,
+    "label: 'Full GitHub Changelog',\n$1href: 'https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md'"
+  );
+
+  if (hasArchive) {
+    // Insert archive category as the last item in docsSidebar before the closing ];
+    const archiveCategory = archiveSidebarCategory();
+    content = content.replace(
+      /(\n  \],\n\};\n)/,
+      `\n${archiveCategory}\n  ],\n};\n`
+    );
+  }
+
+  return content;
+}
+
 async function prepareSidebars(siteRoot, hasArchive) {
   const upstreamSidebars = path.join(workspaceRoot, "content", "upstream", "sidebars.ts");
   const targetSidebars = path.join(siteRoot, "sidebars.ts");
@@ -700,14 +718,7 @@ async function prepareSidebars(siteRoot, hasArchive) {
   if (await exists(upstreamSidebars)) {
     let content = await fs.readFile(upstreamSidebars, "utf8");
 
-    if (hasArchive) {
-      // Insert archive category as the last item in docsSidebar before the closing ];
-      const archiveCategory = archiveSidebarCategory();
-      content = content.replace(
-        /(\n  \],\n\};\n)/,
-        `\n${archiveCategory}\n  ],\n};\n`
-      );
-    }
+    content = siteSidebarSource(content, { hasArchive });
 
     await fs.writeFile(targetSidebars, content, "utf8");
     console.log("Generated sidebars.ts from upstream");

--- a/scripts/prepare-docs.test.mjs
+++ b/scripts/prepare-docs.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  changelogMarkdown,
   docsHomeMarkdown,
   fixProNodeRendererMdx,
   injectProFriendlyNotice,
@@ -87,7 +88,7 @@ test("docs homepage uses current friendly license model copy", () => {
   assert.doesNotMatch(updated, /Friendly evaluation policy/);
 });
 
-test("site sidebar labels the external changelog as the GitHub changelog", () => {
+test("site sidebar replaces the external changelog link with an internal doc reference", () => {
   const source = `const sidebars = {
   docsSidebar: [
     {
@@ -101,9 +102,66 @@ test("site sidebar labels the external changelog as the GitHub changelog", () =>
 
   const updated = siteSidebarSource(source, { hasArchive: false });
 
-  assert.match(updated, /label: 'Full GitHub Changelog'/);
+  assert.match(updated, /type: 'doc'/);
+  assert.match(updated, /id: 'upgrading\/changelog'/);
+  assert.match(updated, /label: 'Changelog'/);
   assert.doesNotMatch(updated, /label: 'Full Changelog'/);
-  assert.match(updated, /CHANGELOG\.md/);
+  assert.doesNotMatch(updated, /github\.com\/shakacode\/react_on_rails\/blob\/main\/CHANGELOG\.md/);
+});
+
+test("changelog markdown injects frontmatter, opts out of MDX, and drops the upstream H1", () => {
+  const source = `# Change Log
+
+All notable changes...
+
+## [Unreleased]
+- Something new. [PR 1](https://example.com/pr/1)
+`;
+
+  const updated = changelogMarkdown(source);
+
+  assert.match(updated, /^---\nid: changelog\n/);
+  assert.match(updated, /title: Changelog/);
+  assert.match(updated, /slug: \/upgrading\/changelog/);
+  assert.match(updated, /mdx:\n {2}format: md/);
+  assert.match(updated, /custom_edit_url: https:\/\/github\.com\/shakacode\/react_on_rails\/edit\/main\/CHANGELOG\.md/);
+  assert.doesNotMatch(updated, /^# Change Log/m);
+  assert.match(updated, /## \[Unreleased\]/);
+  assert.match(updated, /All notable changes\.\.\./);
+});
+
+test("changelog markdown rewrites source-repo-relative links", () => {
+  const source = `# Change Log
+
+- See [Pro config](docs/oss/configuration/configuration-pro.md) and [release notes](docs/oss/upgrading/release-notes/16.0.0.md#breaking-changes).
+- See the [README.md](./README.md).
+- [react_on_rails/spec/dummy](react_on_rails/spec/dummy) is a sample app.
+- External [PR 1](https://github.com/shakacode/react_on_rails/pull/1) is untouched.
+`;
+
+  const updated = changelogMarkdown(source);
+
+  assert.match(updated, /\]\(\/docs\/configuration\/configuration-pro\)/);
+  assert.match(updated, /\]\(\/docs\/upgrading\/release-notes\/16\.0\.0#breaking-changes\)/);
+  assert.match(updated, /\]\(https:\/\/github\.com\/shakacode\/react_on_rails\/blob\/main\/README\.md\)/);
+  assert.match(updated, /\]\(https:\/\/github\.com\/shakacode\/react_on_rails\/tree\/main\/spec\/dummy\)/);
+  assert.match(updated, /\]\(https:\/\/github\.com\/shakacode\/react_on_rails\/pull\/1\)/);
+  assert.doesNotMatch(updated, /docs\/oss\//);
+  assert.doesNotMatch(updated, /\]\(\.\/README\.md\)/);
+});
+
+test("changelog markdown is idempotent on a body without the upstream H1", () => {
+  const source = `Just some preface text.
+
+## [1.0.0]
+- First entry.
+`;
+
+  const updated = changelogMarkdown(source);
+
+  assert.match(updated, /title: Changelog/);
+  assert.match(updated, /Just some preface text\./);
+  assert.match(updated, /## \[1\.0\.0\]/);
 });
 
 test("Pro node renderer table comparisons are escaped for MDX", () => {

--- a/scripts/prepare-docs.test.mjs
+++ b/scripts/prepare-docs.test.mjs
@@ -10,6 +10,7 @@ import {
   injectProFriendlyNotice,
   rewriteFlattenedOssLinks,
   rewriteProLinks,
+  siteSidebarSource,
 } from "./prepare-docs.mjs";
 
 async function withTempDir(callback) {
@@ -84,6 +85,25 @@ test("docs homepage uses current friendly license model copy", () => {
   assert.match(updated, /development, test, CI\/CD, and staging/);
   assert.match(updated, /https:\/\/pro\.reactonrails\.com\//);
   assert.doesNotMatch(updated, /Friendly evaluation policy/);
+});
+
+test("site sidebar labels the external changelog as the GitHub changelog", () => {
+  const source = `const sidebars = {
+  docsSidebar: [
+    {
+      type: 'link',
+      label: 'Full Changelog',
+      href: 'https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md',
+    },
+  ],
+};
+`;
+
+  const updated = siteSidebarSource(source, { hasArchive: false });
+
+  assert.match(updated, /label: 'Full GitHub Changelog'/);
+  assert.doesNotMatch(updated, /label: 'Full Changelog'/);
+  assert.match(updated, /CHANGELOG\.md/);
 });
 
 test("Pro node renderer table comparisons are escaped for MDX", () => {

--- a/scripts/sync-docs.mjs
+++ b/scripts/sync-docs.mjs
@@ -114,6 +114,17 @@ async function main() {
     console.warn("Warning: docs/sidebars.ts not found in source repo");
   }
 
+  // Bring CHANGELOG.md from the source repo root into the upstream tree so the
+  // upstream `docs/oss/upgrading/changelog.md` symlink (`../../../CHANGELOG.md`)
+  // resolves once it's been copied into `content/upstream/docs/`.
+  const sourceChangelog = path.join(sourceRepo, "CHANGELOG.md");
+  if (await exists(sourceChangelog)) {
+    await fs.copyFile(sourceChangelog, path.join(upstreamRoot, "CHANGELOG.md"));
+    console.log(`Synced CHANGELOG.md to ${path.join(upstreamRoot, "CHANGELOG.md")}`);
+  } else {
+    console.warn("Warning: CHANGELOG.md not found in source repo");
+  }
+
   let subsetStats = null;
   if (buildSubset) {
     subsetStats = await writeSubset(fullDocsTarget, subsetDocsTarget, layout);


### PR DESCRIPTION
## Summary

Publish the upstream `CHANGELOG.md` as a docs page at `/docs/upgrading/changelog` instead of sending readers to GitHub. The "Resources › Changelog" footer link and the "Upgrading & Migration" sidebar entry now point at the internal page, so release history stays inside the docs theme (search, sidebar, toc, breadcrumbs).

## What changed

- `scripts/sync-docs.mjs` — also copies `CHANGELOG.md` from the source repo so the dangling symlink in the upstream docs tree has something to render against.
- `scripts/prepare-docs.mjs`:
  - Stops deleting `upgrading/changelog.md`.
  - New `changelogMarkdown()` injects Docusaurus frontmatter, drops the upstream `# Change Log` H1, sets `mdx.format: md` (CommonMark — avoids MDX parsing failures on historical entries that mention raw `<script>`, `<head>`, etc.), and rewrites source-repo-relative links (`docs/oss/<path>.md` → `/docs/<path>`, `./README.md` and `react_on_rails/spec/dummy` → upstream GitHub URLs).
  - `siteSidebarSource` swaps the external "Full Changelog" link for a `type: 'doc'` reference.
- `prototypes/docusaurus/docusaurus.config.ts` — footer Changelog link → `/docs/upgrading/changelog`.
- Tests cover frontmatter injection, H1 strip, link rewrites, and the sidebar swap (`scripts/prepare-docs.test.mjs`).

## Why `mdx.format: md`

The upstream CHANGELOG has historical entries with bare tags like `<script async>`, `<head>`, `<script type="application/json">`. Docusaurus 3 defaults to MDX which tries to parse those as JSX and fails the build. Per-page `mdx: { format: md }` opts this one file into CommonMark.

## Screenshots

Before (footer): "Changelog" was an external link to GitHub.
After (footer): "Changelog" is internal, no external-link icon next to it.

The rendered page has the standard docs chrome (left sidebar, right TOC of versions, breadcrumb "Upgrading & Migration › Changelog"), with PR/contributor refs clickable.

## Test plan
- [x] `node --test scripts/*.test.mjs` — 14 tests pass
- [x] `npm run prepare:docs && npm run build` — build succeeds, no broken links originate from the changelog page
- [x] Browser check: sidebar entry, footer link, page title, intro paragraph, sample PR link all verified at `localhost`
- [ ] Reviewer to spot-check the rendered changelog on the deploy preview

Closes the spirit of #106 (which this PR replaces).
