### PR TITLE
[codex] Clarify changelog section styling

### DIFF
--- a/prototypes/docusaurus/src/css/custom.css
+++ b/prototypes/docusaurus/src/css/custom.css
@@ -155,11 +155,29 @@ body {
   border-bottom: 1px solid var(--site-border);
 }
 
+.markdown h4 {
+  margin-top: 1.35rem;
+  margin-bottom: 0.55rem;
+  font-size: 1.02rem;
+  font-weight: 700;
+  line-height: 1.35;
+  color: var(--ifm-color-content);
+}
+
+.markdown h5 {
+  margin-top: 1.1rem;
+  margin-bottom: 0.45rem;
+  font-size: 0.94rem;
+  font-weight: 700;
+  line-height: 1.35;
+  color: var(--ifm-color-content);
+}
+
 .markdown code {
   background: var(--site-inline-code-surface);
-  border: 1px solid var(--site-border);
-  border-radius: 6px;
-  padding: 0.2em 0.4em;
+  border: 0;
+  border-radius: 4px;
+  padding: 0.12em 0.28em;
   font-family: var(--ifm-font-family-monospace);
   color: var(--site-inline-code-text);
 }

--- a/prototypes/docusaurus/src/css/custom.css
+++ b/prototypes/docusaurus/src/css/custom.css
@@ -158,7 +158,7 @@ body {
 .markdown h4 {
   margin-top: 1.35rem;
   margin-bottom: 0.55rem;
-  font-size: 1.02rem;
+  font-size: 1.12rem;
   font-weight: 700;
   line-height: 1.35;
   color: var(--ifm-color-content);
@@ -167,7 +167,7 @@ body {
 .markdown h5 {
   margin-top: 1.1rem;
   margin-bottom: 0.45rem;
-  font-size: 0.94rem;
+  font-size: 1.02rem;
   font-weight: 700;
   line-height: 1.35;
   color: var(--ifm-color-content);


### PR DESCRIPTION
## Summary

Clarifies lower-level markdown headings so changelog sections like Added, Fixed, and Changed read more clearly as section titles.
Softens inline code styling by removing the bordered chip treatment while keeping a subtle background and monospace text.

## Test plan

- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS in the docs prototype; no runtime, auth, or data paths affected.
> 
> **Overview**
> Updates Docusaurus markdown typography in `custom.css` so **h4** and **h5** read more like section titles (spacing, slightly larger size, bold weight, content color)—intended for changelog-style labels such as Added / Fixed / Changed.
> 
> **Inline `code`** in markdown no longer uses a bordered chip: border is removed, radius and padding are reduced, while background and monospace styling stay in place. Fenced `pre code` rules are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 161243fd7eb1849d0ae7cdfb12049e82b0c76dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->