### PR TITLE
Prominently feature demo + starter apps with live deploy links

### DIFF
--- a/prototypes/docusaurus/src/components/DemoCard/index.tsx
+++ b/prototypes/docusaurus/src/components/DemoCard/index.tsx
@@ -1,0 +1,45 @@
+import type {ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
+
+import type {Demo} from '../../constants/demos';
+import styles from './styles.module.css';
+
+export default function DemoCard({demo}: {demo: Demo}): ReactNode {
+  const {withBaseUrl} = useBaseUrlUtils();
+
+  return (
+    <article className={styles.card}>
+      <div className={styles.media}>
+        {demo.image ? (
+          <img
+            className={styles.image}
+            src={withBaseUrl(demo.image)}
+            alt={`${demo.name} demo screenshot`}
+            loading="lazy"
+          />
+        ) : (
+          <div className={styles.placeholder} aria-hidden="true">
+            <span>{demo.name}</span>
+          </div>
+        )}
+      </div>
+      <div className={styles.body}>
+        <h3 className={styles.title}>{demo.name}</h3>
+        <p className={styles.tagline}>{demo.tagline}</p>
+        <div className={styles.actions}>
+          {demo.demoUrl ? (
+            <Link className={styles.demoLink} href={demo.demoUrl}>
+              View live demo
+            </Link>
+          ) : (
+            <span className={styles.comingSoon}>Demo coming soon</span>
+          )}
+          <Link className={styles.sourceLink} href={demo.repoUrl}>
+            View source
+          </Link>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/prototypes/docusaurus/src/components/DemoCard/styles.module.css
+++ b/prototypes/docusaurus/src/components/DemoCard/styles.module.css
@@ -1,0 +1,81 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--site-border);
+  border-radius: 8px;
+  background: var(--site-surface);
+  overflow: hidden;
+}
+
+.media {
+  aspect-ratio: 16 / 9;
+  background: var(--site-soft-surface);
+  border-bottom: 1px solid var(--site-border);
+}
+
+.image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 1rem;
+  text-align: center;
+  background: linear-gradient(
+    135deg,
+    var(--ifm-color-primary) 0%,
+    var(--ifm-color-primary-darker) 100%
+  );
+}
+
+.placeholder span {
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.2rem;
+  letter-spacing: 0.01rem;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 0.95rem;
+}
+
+.title {
+  margin-bottom: 0.45rem;
+  line-height: 1.12;
+}
+
+.tagline {
+  flex: 1;
+  margin-bottom: 0.9rem;
+  color: var(--ifm-color-content-secondary);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.demoLink,
+.sourceLink {
+  display: inline-flex;
+  align-items: center;
+  font-weight: 700;
+}
+
+.comingSoon {
+  display: inline-flex;
+  align-items: center;
+  font-weight: 700;
+  color: var(--ifm-color-content-secondary);
+}

--- a/prototypes/docusaurus/src/constants/demos.ts
+++ b/prototypes/docusaurus/src/constants/demos.ts
@@ -1,0 +1,67 @@
+export type DemoCategory = 'flagship' | 'starter' | 'legacy';
+
+export type Demo = {
+  /** Slug; also used for the screenshot filename under static/img/demos/. */
+  id: string;
+  name: string;
+  tagline: string;
+  /** GitHub source repository. */
+  repoUrl: string;
+  /** Live deployment. Omit when the deployment is not live yet ("Demo coming soon"). */
+  demoUrl?: string;
+  /** Screenshot/thumbnail path. Omit to render the branded placeholder. */
+  image?: string;
+  category: DemoCategory;
+  /** When true, the demo is featured in the homepage "Live demos" section. */
+  featured?: boolean;
+};
+
+export const demos: Demo[] = [
+  {
+    id: 'hacker-news',
+    name: 'Hacker News',
+    tagline:
+      'A Hacker News reader built on React on Rails Pro with React 19 and React Server Components.',
+    repoUrl: 'https://github.com/shakacode/react-on-rails-demo-hacker-news-rsc',
+    category: 'flagship',
+    featured: true,
+  },
+  {
+    id: 'gumroad',
+    name: 'Gumroad',
+    tagline:
+      'A Gumroad-style creator dashboard comparing Inertia and React on Rails Pro with React 19 and RSC.',
+    repoUrl: 'https://github.com/shakacode/react-on-rails-demo-gumroad-rsc',
+    category: 'flagship',
+    featured: true,
+  },
+  {
+    id: 'marketplace',
+    name: 'Marketplace',
+    tagline:
+      'A marketplace performance demo for React on Rails Pro, React 19, and React Server Components.',
+    repoUrl: 'https://github.com/shakacode/react-on-rails-demo-marketplace-rsc',
+    demoUrl: 'https://rsc.reactonrails.com',
+    category: 'flagship',
+    featured: true,
+  },
+  {
+    id: 'tanstack-starter',
+    name: 'TanStack Starter',
+    tagline: 'A minimal React on Rails + TanStack starter template to build from.',
+    repoUrl: 'https://github.com/shakacode/react-on-rails-starter-tanstack',
+    demoUrl: 'https://start.reactonrails.com',
+    category: 'starter',
+  },
+  {
+    id: 'legacy-tutorial',
+    name: 'Legacy tutorial app',
+    tagline:
+      'The original full-app React on Rails tutorial demo, running in production for years.',
+    repoUrl: 'https://github.com/shakacode/react-webpack-rails-tutorial',
+    demoUrl: 'https://www.reactrails.com',
+    category: 'legacy',
+  },
+];
+
+export const featuredDemos = demos.filter((demo) => demo.featured);

--- a/prototypes/docusaurus/src/constants/demos.ts
+++ b/prototypes/docusaurus/src/constants/demos.ts
@@ -16,25 +16,9 @@ export type Demo = {
   featured?: boolean;
 };
 
+// Live demos lead so the homepage "See it running" section features apps that
+// are actually deployed; coming-soon demos follow and still appear on /examples.
 export const demos: Demo[] = [
-  {
-    id: 'hacker-news',
-    name: 'Hacker News',
-    tagline:
-      'A Hacker News reader built on React on Rails Pro with React 19 and React Server Components.',
-    repoUrl: 'https://github.com/shakacode/react-on-rails-demo-hacker-news-rsc',
-    category: 'flagship',
-    featured: true,
-  },
-  {
-    id: 'gumroad',
-    name: 'Gumroad',
-    tagline:
-      'A Gumroad-style creator dashboard comparing Inertia and React on Rails Pro with React 19 and RSC.',
-    repoUrl: 'https://github.com/shakacode/react-on-rails-demo-gumroad-rsc',
-    category: 'flagship',
-    featured: true,
-  },
   {
     id: 'marketplace',
     name: 'Marketplace',
@@ -52,6 +36,7 @@ export const demos: Demo[] = [
     repoUrl: 'https://github.com/shakacode/react-on-rails-starter-tanstack',
     demoUrl: 'https://start.reactonrails.com',
     category: 'starter',
+    featured: true,
   },
   {
     id: 'legacy-tutorial',
@@ -61,6 +46,23 @@ export const demos: Demo[] = [
     repoUrl: 'https://github.com/shakacode/react-webpack-rails-tutorial',
     demoUrl: 'https://www.reactrails.com',
     category: 'legacy',
+    featured: true,
+  },
+  {
+    id: 'hacker-news',
+    name: 'Hacker News',
+    tagline:
+      'A Hacker News reader built on React on Rails Pro with React 19 and React Server Components.',
+    repoUrl: 'https://github.com/shakacode/react-on-rails-demo-hacker-news-rsc',
+    category: 'flagship',
+  },
+  {
+    id: 'gumroad',
+    name: 'Gumroad',
+    tagline:
+      'A Gumroad-style creator dashboard comparing Inertia and React on Rails Pro with React 19 and RSC.',
+    repoUrl: 'https://github.com/shakacode/react-on-rails-demo-gumroad-rsc',
+    category: 'flagship',
   },
 ];
 

--- a/prototypes/docusaurus/src/pages/examples.module.css
+++ b/prototypes/docusaurus/src/pages/examples.module.css
@@ -10,22 +10,13 @@
 }
 
 .kicker,
-.sectionEyebrow,
-.cardEyebrow {
+.sectionEyebrow {
   margin: 0 0 0.55rem;
   text-transform: uppercase;
   letter-spacing: 0.06rem;
   font-size: 0.75rem;
   font-weight: 700;
-}
-
-.kicker,
-.sectionEyebrow {
   color: var(--ifm-color-primary-dark);
-}
-
-.cardEyebrow {
-  color: var(--ifm-color-content-secondary);
 }
 
 .lead {
@@ -50,39 +41,11 @@
   gap: 0.9rem;
 }
 
-.decisionGrid {
-  margin-bottom: 3rem;
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.card {
-  border: 1px solid var(--site-border);
-  border-radius: 8px;
-  background: var(--site-surface);
-  padding: 0.95rem;
-  box-shadow: none;
-}
-
-.card h3 {
-  margin-bottom: 0.45rem;
-  line-height: 1.12;
-}
-
-.cardLink {
-  display: inline-flex;
-  align-items: center;
-  margin-top: 0;
-  font-weight: 700;
-}
-
 @media (max-width: 996px) {
   .hero {
     padding: 2.1rem 0 1.7rem;
   }
 
-  .decisionGrid,
   .grid {
     grid-template-columns: 1fr;
   }

--- a/prototypes/docusaurus/src/pages/examples.tsx
+++ b/prototypes/docusaurus/src/pages/examples.tsx
@@ -1,133 +1,68 @@
 import type {ReactNode} from 'react';
-import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 
-import {docsRoutes} from '../constants/docsRoutes';
+import {demos, type DemoCategory} from '../constants/demos';
+import DemoCard from '../components/DemoCard';
 import styles from './examples.module.css';
 
-type EvaluationPath = {
+type DemoGroup = {
+  category: DemoCategory;
   eyebrow: string;
-  title: string;
-  description: string;
-  cta: string;
-} & ({to: string; href?: never} | {href: string; to?: never});
+  heading: string;
+};
 
-const evaluationPaths: EvaluationPath[] = [
+const demoGroups: DemoGroup[] = [
   {
-    eyebrow: 'Evaluator path',
-    title: 'Compare setup approaches',
-    description:
-      'Start with the docs landing page to choose between new app setup, existing app install, migration, or Pro evaluation.',
-    to: docsRoutes.docsGuide,
-    cta: 'Open the docs guide',
+    category: 'flagship',
+    eyebrow: 'Flagship demos',
+    heading: 'Production-style apps on React on Rails Pro, React 19, and RSC.',
   },
   {
-    eyebrow: 'Migration path',
-    title: 'Move from react-rails',
-    description:
-      'Follow a migration sequence validated against a real open-source example app instead of reconstructing it from old guides.',
-    to: docsRoutes.migrateFromReactRails,
-    cta: 'Use the react-rails guide',
+    category: 'starter',
+    eyebrow: 'Get started',
+    heading: 'Start a new app from a template.',
   },
   {
-    eyebrow: 'Upgrade path',
-    title: 'Move from OSS to Pro',
-    description:
-      'If your current app needs more SSR throughput or RSC support, compare OSS and Pro, then evaluate Pro without a token before production licensing.',
-    to: docsRoutes.ossVsPro,
-    cta: 'Compare OSS and Pro',
-  },
-  {
-    eyebrow: 'RSC proof path',
-    title: 'Inspect the RSC performance demo',
-    description:
-      'Open the benchmark dashboard for LocalHub, the sample marketplace app, with Lighthouse reports, bundle-size evidence, and SSR/client/RSC comparisons.',
-    href: 'https://rsc.reactonrails.com/search-performance',
-    cta: 'Open RSC benchmark',
-  },
-];
-
-const exampleApps = [
-  {
-    title: 'react_on_rails_demo_ssr_hmr',
-    description:
-      'Canonical demo app showing React on Rails setup with SSR and hot reloading workflows.',
-    href: 'https://github.com/shakacode/react_on_rails_demo_ssr_hmr',
-  },
-  {
-    title: 'react-rails-example-app',
-    description:
-      'Legacy react-rails app used to validate the migration guide and current Rails-version constraints.',
-    href: 'https://github.com/shakacode/react-rails-example-app',
-  },
-  {
-    title: 'vite_ruby/examples/rails',
-    description:
-      'Official Vite Rails sample app used to document migration preflight and dependency lockfile issues.',
-    href: 'https://github.com/ElMassimo/vite_ruby/tree/main/examples/rails',
-  },
-  {
-    title: 'react-on-rails-demo-marketplace-rsc',
-    description:
-      'Public React on Rails Pro + RSC marketplace demo behind the LocalHub sample app Lighthouse and bundle-size comparisons.',
-    href: 'https://github.com/shakacode/react-on-rails-demo-marketplace-rsc',
+    category: 'legacy',
+    eyebrow: 'Legacy',
+    heading: 'The original full-app tutorial demo.',
   },
 ];
 
 export default function ExamplesPage(): ReactNode {
   return (
-    <Layout title="Examples" description="React on Rails example applications and references">
+    <Layout title="Examples" description="React on Rails demo and starter applications">
       <main className={styles.main}>
         <section className={styles.hero}>
           <div className="container">
-            <p className={styles.kicker}>Examples and migration references</p>
-            <h1>Use concrete repos and concrete guides when deciding whether React on Rails fits.</h1>
+            <p className={styles.kicker}>Demos and starters</p>
+            <h1>See React on Rails running, then read the source.</h1>
             <p className={styles.lead}>
-              These links are meant for evaluation, migration, and validation work. They are not a
-              parallel docs track.
+              Every demo links to a live deployment and its source code. Use them to evaluate
+              React on Rails, compare OSS and Pro, or start a new app.
             </p>
           </div>
         </section>
 
-        <section className="container">
-          <div className={styles.sectionHeader}>
-            <p className={styles.sectionEyebrow}>Start with a decision path</p>
-            <h2>Choose the guide that matches your migration or evaluation goal.</h2>
-          </div>
-          <div className={styles.decisionGrid}>
-            {evaluationPaths.map((path) => (
-              <article className={styles.card} key={path.title}>
-                <p className={styles.cardEyebrow}>{path.eyebrow}</p>
-                <h3>{path.title}</h3>
-                <p>{path.description}</p>
-                <Link
-                  className={styles.cardLink}
-                  {...('href' in path ? {href: path.href} : {to: path.to})}
-                >
-                  {path.cta}
-                </Link>
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <section className="container">
-          <div className={styles.sectionHeader}>
-            <p className={styles.sectionEyebrow}>Reference repos</p>
-            <h2>Public apps and demos that map to the docs.</h2>
-          </div>
-          <div className={styles.grid}>
-            {exampleApps.map((app) => (
-              <article className={styles.card} key={app.title}>
-                <h3>{app.title}</h3>
-                <p>{app.description}</p>
-                <Link className={styles.cardLink} href={app.href}>
-                  Open repository
-                </Link>
-              </article>
-            ))}
-          </div>
-        </section>
+        {demoGroups.map((group) => {
+          const groupDemos = demos.filter((demo) => demo.category === group.category);
+          if (groupDemos.length === 0) {
+            return null;
+          }
+          return (
+            <section className="container" key={group.category}>
+              <div className={styles.sectionHeader}>
+                <p className={styles.sectionEyebrow}>{group.eyebrow}</p>
+                <h2>{group.heading}</h2>
+              </div>
+              <div className={styles.grid}>
+                {groupDemos.map((demo) => (
+                  <DemoCard demo={demo} key={demo.id} />
+                ))}
+              </div>
+            </section>
+          );
+        })}
       </main>
     </Layout>
   );

--- a/prototypes/docusaurus/src/pages/index.module.css
+++ b/prototypes/docusaurus/src/pages/index.module.css
@@ -110,15 +110,31 @@
 
 .quickStartGrid,
 .valueGrid,
-.migrationGrid {
+.migrationGrid,
+.demoGrid {
   display: grid;
   gap: 0.9rem;
   min-width: 0;
 }
 
 .quickStartGrid,
-.valueGrid {
+.valueGrid,
+.demoGrid {
   grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.sectionHeaderRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.browseAll {
+  flex-shrink: 0;
+  font-weight: 700;
+  white-space: nowrap;
 }
 
 .migrationGrid {
@@ -328,6 +344,7 @@
   .quickStartGrid,
   .valueGrid,
   .migrationGrid,
+  .demoGrid,
   .quoteGrid,
   .featureLayout {
     grid-template-columns: 1fr;

--- a/prototypes/docusaurus/src/pages/index.tsx
+++ b/prototypes/docusaurus/src/pages/index.tsx
@@ -6,6 +6,8 @@ import Layout from '@theme/Layout';
 import ThemedImage from '@theme/ThemedImage';
 
 import {docsRoutes} from '../constants/docsRoutes';
+import {featuredDemos} from '../constants/demos';
+import DemoCard from '../components/DemoCard';
 import styles from './index.module.css';
 
 const quickStartCards = [
@@ -201,6 +203,29 @@ function QuickStartSection() {
   );
 }
 
+function LiveDemosSection() {
+  return (
+    <section className={styles.sectionSoft}>
+      <div className="container">
+        <div className={styles.sectionHeaderRow}>
+          <div className={styles.sectionHeader}>
+            <p className={styles.sectionEyebrow}>Live demos</p>
+            <h2>See it running</h2>
+          </div>
+          <Link className={styles.browseAll} to="/examples">
+            Browse all demos →
+          </Link>
+        </div>
+        <div className={styles.demoGrid}>
+          {featuredDemos.map((demo) => (
+            <DemoCard demo={demo} key={demo.id} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function ProSection() {
   const proLogoSrc = useBaseUrl('/img/logo-mark-pro.svg');
 
@@ -355,6 +380,7 @@ export default function Home(): ReactNode {
       <HeroSection />
       <main>
         <QuickStartSection />
+        <LiveDemosSection />
         <ProSection />
         <ValueSection />
         <TrustedBySection />


### PR DESCRIPTION
## What

Give the maintained React on Rails demo and starter apps real prominence, with links to **both** the live deployment and the source for each.

### Homepage — new "See it running" section (right after Quick Start)
Features the 3 **live** demos so the section only shows apps that are actually running: **Marketplace**, **TanStack Starter**, **Legacy tutorial**, plus a "Browse all demos →" link to `/examples`.

### Examples page — overhaul
- **Removed** the "Decision Path" cards (those were doc links, not examples) and the stale repo list (`react_on_rails_demo_ssr_hmr` old slug, `react-rails-example-app`, `vite_ruby`).
- **Now** shows demos grouped as **Flagship demos** / **Get started** / **Legacy**, each card with source + live links. Coming-soon demos appear under Flagship.

## Demos (single source of truth: `src/constants/demos.ts`)

Ordered so live deployments lead:

| Demo | Repo | Live | Homepage |
| --- | --- | --- | --- |
| Marketplace | `react-on-rails-demo-marketplace-rsc` | rsc.reactonrails.com | ✓ |
| TanStack Starter | `react-on-rails-starter-tanstack` | start.reactonrails.com | ✓ |
| Legacy tutorial | `react-webpack-rails-tutorial` | www.reactrails.com | ✓ |
| Hacker News | `react-on-rails-demo-hacker-news-rsc` | coming soon | — |
| Gumroad | `react-on-rails-demo-gumroad-rsc` | coming soon | — |

## Design notes
- Reusable `DemoCard` component shared by both pages.
- Each card has a graphic slot. Until real screenshots land it renders a **branded placeholder** tile, so nothing looks broken. Screenshots drop into `static/img/demos/<id>.png` later and are wired by setting `image` on the entry — **no code change**.
- Demos without a live URL render a non-clickable **"Demo coming soon"** chip; the source link is always present.

## Followups
- **#113** — add real screenshots/thumbnails for each demo.
- Confirm the Hacker News and Gumroad deployment URLs; set `demoUrl` on those entries to flip "coming soon" to a live link (and they become eligible to feature on the homepage).

## Test plan
- [x] `npm run typecheck` (tsc) passes
- [x] `npm run build` succeeds (broken-link warnings are pre-existing `/docs/*` upstream content, unrelated to these pages)
- [x] Manual: homepage shows the 3 live demos after Quick Start; `/examples` shows grouped demos with correct live/source/coming-soon states; no new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
