### PR TITLE
Document live Hacker News demo

### DIFF
--- a/prototypes/docusaurus/src/constants/demos.ts
+++ b/prototypes/docusaurus/src/constants/demos.ts
@@ -54,7 +54,9 @@ export const demos: Demo[] = [
     tagline:
       'A Hacker News reader built on React on Rails Pro with React 19 and React Server Components.',
     repoUrl: 'https://github.com/shakacode/react-on-rails-demo-hacker-news-rsc',
+    demoUrl: 'https://hn.reactonrails.com',
     category: 'flagship',
+    featured: true,
   },
   {
     id: 'gumroad',


### PR DESCRIPTION
## Summary
- Link the Hacker News demo card to the live deployment at https://hn.reactonrails.com
- Include it in the homepage live demos set now that the deployment is available

## Test Plan
- `npm run prepare`
- `npm run build` (passes; existing Docusaurus broken-link/broken-anchor warnings are still reported)
- `curl -I https://hn.reactonrails.com/` returns HTTP 200

Labels: none. Docs/site data only; no CI expansion needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/site data only; no runtime or security impact.
> 
> **Overview**
> The **Hacker News** demo entry in `demos.ts` now points at the live site **`https://hn.reactonrails.com`** and is marked **`featured: true`**, so it appears in the homepage “Live demos” section and demo cards show **View live demo** instead of **Demo coming soon**.
> 
> No UI or routing code changes—only demo metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 972ca2e782c5836afe491f05f050e653d64a1243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->