### PR TITLE
Fix TanStack starter demo link

### DIFF
--- a/prototypes/docusaurus/src/constants/demos.ts
+++ b/prototypes/docusaurus/src/constants/demos.ts
@@ -34,7 +34,7 @@ export const demos: Demo[] = [
     name: 'TanStack Starter',
     tagline: 'A minimal React on Rails + TanStack starter template to build from.',
     repoUrl: 'https://github.com/shakacode/react-on-rails-starter-tanstack',
-    demoUrl: 'https://start.reactonrails.com',
+    demoUrl: 'https://starter.reactonrails.com',
     category: 'starter',
     featured: true,
   },


### PR DESCRIPTION
## Summary
- update the TanStack Starter demo link on the examples page from https://start.reactonrails.com to https://starter.reactonrails.com
- keep starter.reactonrails.com as the canonical hostname

## Validation
- npm run build
  - exits 0
  - Docusaurus still reports pre-existing broken-link and broken-anchor warnings unrelated to this one-line change

## Repo search
- exact org search for start.reactonrails.com returned no remaining indexed hits after this branch change
- broader org search for https://start found one unrelated private licensing test fixture

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change in documentation/marketing config with no runtime or security impact.
> 
> **Overview**
> Updates the **TanStack Starter** live demo link on the examples/homepage demos list from `https://start.reactonrails.com` to **`https://starter.reactonrails.com`**, aligning the site with the canonical starter hostname.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee7ae9c534c2494cd69f5afae93a7dd7f6ce8210. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->