### PR TITLE
Add Octochangelog to examples

### DIFF
--- a/prototypes/docusaurus/src/constants/demos.ts
+++ b/prototypes/docusaurus/src/constants/demos.ts
@@ -59,6 +59,16 @@ export const demos: Demo[] = [
     featured: true,
   },
   {
+    id: 'octochangelog',
+    name: 'Octochangelog',
+    tagline:
+      'An Octochangelog app migrated to React on Rails Pro with Rails routing, React 19, and streamed RSC.',
+    repoUrl: 'https://github.com/shakacode/react_on_rails-demo-octochangelog-on-rails-pro',
+    demoUrl: 'https://rails-wt0q7a2r1svry.cpln.app',
+    category: 'flagship',
+    featured: true,
+  },
+  {
     id: 'gumroad',
     name: 'Gumroad',
     tagline:


### PR DESCRIPTION
## Summary
- add Octochangelog to the React on Rails examples data
- point the demo at the live Control Plane staging URL
- link to the React on Rails Pro demo repository

## Validation
- npm run install:site
- npm --prefix prototypes/docusaurus run typecheck

## Note
- npm run build currently fails in this workspace because the generated docs/sidebar subset references missing docs after npm run prepare:subset; I restored the generated sidebar side effect and kept this PR scoped to the examples data change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only addition to static demo metadata; no auth, data, or application logic changes.
> 
> **Overview**
> Adds **Octochangelog** as a new flagship, featured example in `demos.ts`, with links to the React on Rails Pro demo repo and the live Control Plane staging URL.
> 
> The site’s `/examples` page and homepage “Live demos” section pick up the entry automatically via the existing `demos` / `featuredDemos` wiring—no other code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6394def516accc0ba2cb8e80808e2c4768b2fa42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->