### PR TITLE
Normalize UI label capitalization to sentence case

### DIFF
--- a/prototypes/docusaurus/docusaurus.config.ts
+++ b/prototypes/docusaurus/docusaurus.config.ts
@@ -157,15 +157,15 @@ const config: Config = {
           title: 'Docs',
           items: [
             {
-              label: 'Documentation Guide',
+              label: 'Documentation guide',
               to: '/docs',
             },
-            {label: 'Create a New App', to: '/docs/getting-started/create-react-on-rails-app'},
+            {label: 'Create a new app', to: '/docs/getting-started/create-react-on-rails-app'},
             {
-              label: 'Install into Existing Rails App',
+              label: 'Install into existing Rails app',
               to: '/docs/getting-started/existing-rails-app',
             },
-            {label: 'Quick Start', to: '/docs/getting-started/quick-start'},
+            {label: 'Quick start', to: '/docs/getting-started/quick-start'},
             {label: 'Compare OSS and Pro', to: '/docs/getting-started/oss-vs-pro'},
             {label: 'Upgrade to Pro', to: '/docs/pro/upgrading-to-pro'},
             {label: 'React on Rails Pro', to: '/docs/pro'},
@@ -204,7 +204,7 @@ const config: Config = {
               to: '/pro',
             },
             {
-              label: 'Pro Pricing & Sign Up',
+              label: 'Pro pricing & sign up',
               href: 'https://pro.reactonrails.com/',
             },
             {

--- a/prototypes/docusaurus/src/pages/index.tsx
+++ b/prototypes/docusaurus/src/pages/index.tsx
@@ -12,21 +12,21 @@ import styles from './index.module.css';
 
 const quickStartCards = [
   {
-    title: 'Create App',
+    title: 'Create app',
     command: 'npx create-react-on-rails-app@latest my-app',
     description: 'Scaffold a working Rails + React app with TypeScript defaults.',
     href: docsRoutes.createApp,
     cta: 'Open guide',
   },
   {
-    title: 'Install Into Rails',
+    title: 'Install into Rails',
     command: 'bundle exec rails generate react_on_rails:install --typescript',
     description: 'Add React on Rails to an existing app while keeping Rails routes and conventions.',
     href: docsRoutes.installExistingApp,
     cta: 'Open guide',
   },
   {
-    title: 'Upgrade To Pro',
+    title: 'Upgrade to Pro',
     command: 'bundle add react_on_rails_pro',
     description: 'Evaluate Pro SSR, streaming, and RSC paths before buying a production license.',
     href: docsRoutes.proUpgrade,
@@ -46,7 +46,7 @@ const valueCards = [
       'Use server rendering, hydration, and streaming paths that fit mature Rails deployments.',
   },
   {
-    title: 'OSS And Pro',
+    title: 'OSS and Pro',
     description:
       'Start with open source docs, then add Pro when SSR throughput, RSC support, or guided support matters.',
   },
@@ -164,7 +164,7 @@ function HeroSection() {
           </p>
           <div className={styles.buttons}>
             <Link className="button button--primary button--lg" to={docsRoutes.docsGuide}>
-              Browse Docs
+              Browse docs
             </Link>
             <Link className="button button--secondary button--lg" to="/examples">
               Examples


### PR DESCRIPTION
## What

Standardizes the remaining Title-Case nav, footer, and homepage button labels on **sentence case** — the convention already used by most action labels on the site and the modern default for UI copy (GOV.UK, Shopify Polaris, Atlassian, IBM Carbon, Material 3). Proper nouns stay capitalized.

Split out from #122 (demo naming + consultation CTA consistency) to keep each PR focused. The navbar consultation CTA was already sentence-cased in #122.

## Changes (label text only)

**Footer**

| Before | After |
|---|---|
| Documentation Guide | Documentation guide |
| Create a New App | Create a new app |
| Install into Existing Rails App | Install into existing Rails app |
| Quick Start | Quick start |
| Pro Pricing & Sign Up | Pro pricing & sign up |

**Homepage**

| Before | After |
|---|---|
| Browse Docs (hero) | Browse docs |
| Create App (card) | Create app |
| Install Into Rails (card) | Install into Rails |
| Upgrade To Pro (card) | Upgrade to Pro |
| OSS And Pro (card) | OSS and Pro |

Proper nouns preserved: **React on Rails, React on Rails Pro, OSS, RSC, Rails, GitHub, ShakaCode**. Out of scope (left as-is): section headings/eyebrows (e.g. "Why Teams Use It") — those are content headings, a separate concern.

## Verification

- `npm run build` → `[SUCCESS]`.
- Diff is exactly 10 label lines across `docusaurus.config.ts` and `src/pages/index.tsx`; no logic or layout changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only label updates in site config and homepage; no routing, logic, or security impact.
> 
> **Overview**
> Aligns remaining **footer** and **homepage** nav/link labels with **sentence case** (e.g. “Documentation guide”, “Browse docs”, “Create app”) instead of title case, matching other UI copy on the site.
> 
> Updates are **string-only** in `docusaurus.config.ts` (five footer doc/More links) and `src/pages/index.tsx` (hero CTA plus four quick-start/value card titles). **Proper nouns** such as React on Rails, Pro, OSS, and Rails stay capitalized; routes and behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7780c2027690504789517a5808181de4a3eeb29c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text capitalization across the homepage and footer navigation. Button labels, card titles, and section headers now use sentence-case formatting for improved consistency throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->