### PR TITLE
Update Gumroad example card to public product route

### DIFF
--- a/prototypes/docusaurus/src/constants/demos.ts
+++ b/prototypes/docusaurus/src/constants/demos.ts
@@ -77,7 +77,7 @@ export const demos: Demo[] = [
     id: 'gumroad',
     name: 'Gumroad',
     tagline:
-      'A public product-page benchmark comparing Inertia and React on Rails Pro with React 19 and RSC.',
+      'A public product-page demo comparing Inertia and React on Rails Pro with React 19 and RSC.',
     repoUrl: 'https://github.com/shakacode/react-on-rails-demo-gumroad-rsc',
     demoUrl: 'https://gumroad.reactonrails.com/public_product/rsc_demo',
     image: '/img/demos/gumroad.webp',

--- a/prototypes/docusaurus/src/constants/demos.ts
+++ b/prototypes/docusaurus/src/constants/demos.ts
@@ -77,9 +77,9 @@ export const demos: Demo[] = [
     id: 'gumroad',
     name: 'Gumroad',
     tagline:
-      'A Gumroad-style creator dashboard comparing Inertia and React on Rails Pro with React 19 and RSC.',
+      'A public product-page benchmark comparing Inertia and React on Rails Pro with React 19 and RSC.',
     repoUrl: 'https://github.com/shakacode/react-on-rails-demo-gumroad-rsc',
-    demoUrl: 'https://gumroad.reactonrails.com',
+    demoUrl: 'https://gumroad.reactonrails.com/public_product/rsc_demo',
     image: '/img/demos/gumroad.webp',
     category: 'flagship',
     featured: true,


### PR DESCRIPTION
## Summary

- Repoint the Gumroad example card to the public product-page RSC demo route.
- Reword the card away from the old auth-gated creator dashboard comparison.
- Use "demo" rather than "benchmark" to avoid overclaiming while hosted performance proof is still in progress.
- Aligns the examples page with shakacode/react-on-rails-demo-gumroad-rsc#25 and reactonrails.com#121.

## Validation

- `npm --prefix prototypes/docusaurus run typecheck`
- `REACT_ON_RAILS_REPO=/tmp/react-on-rails-ci-docs-source-missing REACT_ON_RAILS_REPO_URL=https://github.com/shakacode/react_on_rails.git REACT_ON_RAILS_REF=main npm run prepare`
- `npm run build`

Build completed successfully. It still emits existing docs broken-link/anchor warnings unrelated to this card change.

## Merge note

The original route gate is now satisfied: `https://gumroad.reactonrails.com/public_product/rsc_demo` returns 200. Merge when the fresh site CI and preview deploy complete.