### PR TITLE
Reduce stale Cloudflare deploy work

### DIFF
--- a/.github/workflows/site-build-deploy.yml
+++ b/.github/workflows/site-build-deploy.yml
@@ -12,6 +12,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: site-build-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -71,6 +75,14 @@ jobs:
           ALGOLIA_SEARCH_API_KEY: ${{ vars.ALGOLIA_SEARCH_API_KEY }}
           ALGOLIA_INDEX_NAME: ${{ vars.ALGOLIA_INDEX_NAME }}
 
+      - name: Upload built site
+        uses: actions/upload-artifact@v4
+        with:
+          name: docusaurus-build
+          path: prototypes/docusaurus/build
+          if-no-files-found: error
+          retention-days: 1
+
   deploy:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     needs: build
@@ -87,24 +99,11 @@ jobs:
         with:
           node-version: 24
 
-      - name: Sync docs
-        run: npm run sync:docs
-        env:
-          REACT_ON_RAILS_REPO_URL: https://github.com/shakacode/react_on_rails.git
-          REACT_ON_RAILS_REF: main
-
-      - name: Prepare docs
-        run: npm run prepare:docs
-
-      - name: Install site dependencies
-        run: npm --prefix prototypes/docusaurus install
-
-      - name: Build site
-        run: npm run build
-        env:
-          ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
-          ALGOLIA_SEARCH_API_KEY: ${{ vars.ALGOLIA_SEARCH_API_KEY }}
-          ALGOLIA_INDEX_NAME: ${{ vars.ALGOLIA_INDEX_NAME }}
+      - name: Download built site
+        uses: actions/download-artifact@v4
+        with:
+          name: docusaurus-build
+          path: prototypes/docusaurus/build
 
       - name: Determine deploy branch
         id: deploy_branch


### PR DESCRIPTION
Adds workflow concurrency so superseded site deploy runs for the same ref are canceled instead of piling up.
Uploads the built Docusaurus site from the build job and downloads it in deploy, so Cloudflare deploys the audited build output without rebuilding.
Validation: actionlint .github/workflows/site-build-deploy.yml and git diff --check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change; deploy now depends on the build artifact, which is standard but could block deploy if upload/download fails.
> 
> **Overview**
> **Reduces queued Cloudflare deploy work** by adding workflow **concurrency** on `site-build-deploy-${{ github.ref }}` with **cancel-in-progress**, so newer runs for the same ref supersede older ones instead of stacking.
> 
> **Splits build from deploy more strictly:** the **build** job now **uploads** the Docusaurus output as a short-lived `docusaurus-build` artifact after the existing docs audit and build steps. The **deploy** job **downloads** that artifact and runs Wrangler against it, removing the duplicate sync/prepare/install/build steps that previously rebuilt the site in deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65566a84a6057a6ae831cc84cc558ef52212dcd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the site build and deployment workflow by implementing concurrency controls to prevent overlapping runs and reusing build artifacts during deployment, improving efficiency and reducing redundant build steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->