### PR TITLE
Add trusted GitHub actor allowlist

### DIFF
--- a/.agents/trusted-github-actors.yml
+++ b/.agents/trusted-github-actors.yml
@@ -15,6 +15,10 @@ trusted_bots:
   - cursor
   - dependabot
   - greptile-apps
+  # Current use is limited to the deterministic Cloudflare Pages preview
+  # comment in `.github/workflows/site-build-deploy.yml`. Do not add new
+  # `GITHUB_TOKEN` comment workflows without a distinct bot/app identity or a
+  # matching provenance check in the batch preflight tool.
   - github-actions
 
 # Team entries are GitHub team slugs under the repository owner org. Reading

--- a/.agents/trusted-github-actors.yml
+++ b/.agents/trusted-github-actors.yml
@@ -1,0 +1,23 @@
+# GitHub actors whose public issue/PR/review comments may be acted on by
+# PR-batch automation. Keep this list deliberately strict: unknown actors are
+# queued for maintainer triage, not interpreted as instructions.
+trusted_users:
+  - justin808
+
+# Bot entries are base bot names. GitHub API logins usually include the
+# `[bot]` suffix; humans with the same base login are not trusted by this list.
+# Trusted bots are exempt from hidden-participant blocking, so keep this list
+# limited to bot identities whose generated PR content is safe to process.
+trusted_bots:
+  - chatgpt-codex-connector
+  - claude
+  - coderabbitai
+  - cursor
+  - dependabot
+  - greptile-apps
+  - github-actions
+
+# Team entries are GitHub team slugs under the repository owner org. Reading
+# team membership requires the local GitHub token to have org access.
+trusted_teams:
+  - shakacode


### PR DESCRIPTION
## Summary
- add the repo-local trusted GitHub actor allowlist used by `pr-security-preflight`
- seed the policy from `react_on_rails` and include this repo's `github-actions` preview-comment bot
- unblock the current exact PR batch without broadening trust to unknown actors

## Why
The current batch security preflight failed because `reactonrails.com` had no `.agents/trusted-github-actors.yml`, so all PR authors, reviewers, and preview-comment bots were treated as untrusted. This file makes the trust boundary explicit and auditable in this repo.

## Test plan
- `PR_BATCH_SKILL_DIR=/Users/justin/.codex/skills/pr-batch; "$PR_BATCH_SKILL_DIR/bin/pr-security-preflight" --repo shakacode/reactonrails.com 131 130 102 132 129 113`
- `npm run install:site`
- `npm run prepare`
- `npm run build` (passes; Docusaurus reports existing generated-doc broken-link/anchor warnings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened which GitHub accounts can trigger automation from public comments.
  * Unrecognized comments are now left for maintainer review instead of being treated as instructions, reducing accidental actions and improving safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->