### PR TITLE
docs: add a TanStack Query value card to the home page

### DIFF
--- a/prototypes/docusaurus/src/constants/prompts.ts
+++ b/prototypes/docusaurus/src/constants/prompts.ts
@@ -26,7 +26,7 @@ export const prompts: Prompt[] = [
   {
     "id": "create-app",
     "title": "Start a new app",
-    "prompt": "Set up a new Rails app with React on Rails, using TypeScript and server-side rendering. Follow the official guide at https://reactonrails.com/docs/getting-started/create-react-on-rails-app and use the exact commands and versions it specifies — don't improvise.",
+    "prompt": "Set up a new Rails app using the default React on Rails Pro path (no token required for development, test, CI/CD, or staging; production requires a paid license) with TypeScript and server-side rendering. Follow the official guide at https://reactonrails.com/docs/getting-started/create-react-on-rails-app exactly; don't improvise commands or versions. Use --standard only when you intentionally want an open-source-only scaffold.",
     "href": "/docs/getting-started/create-react-on-rails-app",
     "category": "get-started"
   },

--- a/prototypes/docusaurus/src/pages/index.tsx
+++ b/prototypes/docusaurus/src/pages/index.tsx
@@ -28,6 +28,11 @@ const valueCards = [
     description:
       'Start with open source docs, then add Pro when SSR throughput, RSC support, or guided support matters.',
   },
+  {
+    title: 'Modern data fetching',
+    description:
+      'Pair Rails JSON APIs with TanStack Query for client-side caching, mutations, and first-paint data, without adding a second backend.',
+  },
 ];
 
 const migrationGuides = [

--- a/prototypes/docusaurus/static/prompts.json
+++ b/prototypes/docusaurus/static/prompts.json
@@ -41,7 +41,7 @@
       "category": "get-started",
       "doc_route": "/docs/getting-started/create-react-on-rails-app",
       "doc_url": "https://reactonrails.com/docs/getting-started/create-react-on-rails-app",
-      "prompt": "Set up a new Rails app with React on Rails, using TypeScript and server-side rendering. Follow the official guide at https://reactonrails.com/docs/getting-started/create-react-on-rails-app and use the exact commands and versions it specifies — don't improvise."
+      "prompt": "Set up a new Rails app using the default React on Rails Pro path (no token required for development, test, CI/CD, or staging; production requires a paid license) with TypeScript and server-side rendering. Follow the official guide at https://reactonrails.com/docs/getting-started/create-react-on-rails-app exactly; don't improvise commands or versions. Use --standard only when you intentionally want an open-source-only scaffold."
     },
     {
       "id": "install-existing",

--- a/prototypes/docusaurus/static/prompts/llms.txt
+++ b/prototypes/docusaurus/static/prompts/llms.txt
@@ -13,7 +13,7 @@ ID: create-app
 Category: get-started
 Doc: https://reactonrails.com/docs/getting-started/create-react-on-rails-app
 
-Set up a new Rails app with React on Rails, using TypeScript and server-side rendering. Follow the official guide at https://reactonrails.com/docs/getting-started/create-react-on-rails-app and use the exact commands and versions it specifies — don't improvise.
+Set up a new Rails app using the default React on Rails Pro path (no token required for development, test, CI/CD, or staging; production requires a paid license) with TypeScript and server-side rendering. Follow the official guide at https://reactonrails.com/docs/getting-started/create-react-on-rails-app exactly; don't improvise commands or versions. Use --standard only when you intentionally want an open-source-only scaffold.
 
 ### Add to an existing Rails app
 


### PR DESCRIPTION
Adds a **Modern data fetching** value card to the home page mentioning TanStack Query (client-side caching, mutations, and first-paint data on a Rails JSON API, without a second backend).

Scope note: the examples page already lists the TanStack Starter card (`demos.ts`), and the [Using TanStack Query guide](https://reactonrails.com/docs/building-features/tanstack-query) auto-syncs into `/docs` at build — so the blurb is the only content addition.

**Second commit (CI fix):** refreshes the generated prompt artifacts (`prompts.ts` / `prompts.json` / `prompts/llms.txt`) from upstream `prompts.yml`. The `prepare:prompts` guard was failing on *every* PR because those committed artifacts lagged react_on_rails main (shakacode/react_on_rails#4232). Verified locally: `npm run build` (prepare:prompts:check + docusaurus build) passes.

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated app-start guidance to clarify the default setup, licensing requirements across environments, and when to use the standard open-source scaffold.
* **New Features**
  * Added a new homepage highlight about modern data fetching, showing how Rails JSON APIs can pair with TanStack Query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->