### PR TITLE
Surface migration guides in site navigation

### DIFF
--- a/prototypes/docusaurus/sidebars.ts
+++ b/prototypes/docusaurus/sidebars.ts
@@ -173,8 +173,10 @@ const sidebars: SidebarsConfig = {
           label: 'Migration Guides',
           items: [
             'migrating/example-migrations',
-            'migrating/migrating-from-react-rails',
+            'migrating/migrating-from-inertia-rails',
             'migrating/migrating-from-vite-rails',
+            'migrating/migrating-from-nextjs',
+            'migrating/migrating-from-react-rails',
             'migrating/migrating-from-webpack-to-rspack',
             'migrating/babel-to-swc-migration',
             'migrating/convert-rails-5-api-only-app',

--- a/prototypes/docusaurus/src/constants/docsRoutes.ts
+++ b/prototypes/docusaurus/src/constants/docsRoutes.ts
@@ -13,5 +13,8 @@ export const docsRoutes = {
   proAsyncRendering:
     '/docs/api-reference/ruby-api-pro#async_react_componentcomponent_name-options--',
   codeSplitting: '/docs/building-features/code-splitting',
+  migrateFromInertiaRails: '/docs/migrating/migrating-from-inertia-rails',
+  migrateFromViteRails: '/docs/migrating/migrating-from-vite-rails',
+  migrateFromNextjs: '/docs/migrating/migrating-from-nextjs',
   migrateFromReactRails: '/docs/migrating/migrating-from-react-rails',
 } as const;

--- a/prototypes/docusaurus/src/pages/index.module.css
+++ b/prototypes/docusaurus/src/pages/index.module.css
@@ -145,7 +145,7 @@
 }
 
 .migrationGrid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .valueCard,

--- a/prototypes/docusaurus/src/pages/index.tsx
+++ b/prototypes/docusaurus/src/pages/index.tsx
@@ -37,6 +37,24 @@ const valueCards = [
 
 const migrationGuides = [
   {
+    title: 'Migrate from Inertia Rails',
+    description:
+      'Move from Inertia page props and SPA navigation to React on Rails view helpers route by route.',
+    href: docsRoutes.migrateFromInertiaRails,
+  },
+  {
+    title: 'Migrate from vite_rails',
+    description:
+      'Switch from vite_rails when you want Rails view helpers, SSR, or React on Rails Pro features.',
+    href: docsRoutes.migrateFromViteRails,
+  },
+  {
+    title: 'Migrate from Next.js',
+    description:
+      'Collapse a separate Next.js frontend into Rails while keeping a modern React migration path.',
+    href: docsRoutes.migrateFromNextjs,
+  },
+  {
     title: 'Migrate from react-rails',
     description:
       'Step-by-step checklist for swapping `react-rails` to React on Rails, with a sample app.',
@@ -269,7 +287,7 @@ function MigrationSection() {
       <div className="container">
         <div className={styles.sectionHeader}>
           <p className={styles.sectionEyebrow}>Migration</p>
-          <h2>Move from another setup</h2>
+          <h2>Switch from another React setup</h2>
         </div>
         <div className={styles.migrationGrid}>
           {migrationGuides.map((guide) => (


### PR DESCRIPTION
## Summary
- Add route constants for the Inertia, vite-rails, and Next.js migration guides.
- Surface those guides in the homepage migration card grid.
- Add the guides to the generated Docusaurus sidebar source so they are reachable from docs navigation.

## Why
Issue #141 asks for the migration guides to be discoverable from the docs index and homepage. The guides already exist in synced upstream docs; this PR updates the site-owned navigation surfaces without editing generated docs.

Closes #141

## Test plan
- `npm run sync:docs`
- `npm run prepare:docs`
- `.agents/bin/validate`

## Codex Decision Log
- **Non-blocking:** Whether to edit generated docs index copy.
  - **Decision:** Do not edit generated docs; expose the existing guide routes from site-owned homepage, route constants, and sidebar source.
  - **Why:** AGENTS.md says generated docs are rebuilt from upstream and should not be edited directly.
  - **Review later:** Upstream docs index copy can be handled in react_on_rails if maintainers want a docs-index prose change.