### PR TITLE
Use trust-based commercial licensing copy

### DIFF
--- a/prototypes/docusaurus/src/pages/pro.tsx
+++ b/prototypes/docusaurus/src/pages/pro.tsx
@@ -77,9 +77,9 @@ const upgradeSteps = [
   },
   {
     step: '3',
-    title: 'License when you deploy',
+    title: 'Align licensing before production',
     description:
-      'Confirm production rendering and performance on the paths that matter, then add a license when you ship.',
+      'Confirm production rendering and performance on the paths that matter, then add a paid license before private business value ships.',
   },
 ];
 
@@ -95,14 +95,15 @@ export default function ProPage(): ReactNode {
             <p>
               Pro adds React Server Components, streaming SSR, concurrent and cached rendering, and a
               dedicated Node renderer on top of the open-source gem. The gem and npm package are
-              public — install and build today; you only need a license to deploy to production.
+              public — install and build today under ShakaCode Trust-Based Commercial Licensing.
             </p>
             <code className={styles.install}>bundle add react_on_rails_pro</code>
             <div className={styles.licenseHighlight}>
-              <strong>Free to build with</strong>
+              <strong>Free to learn. Paid for private business value.</strong>
               <span>
-                No token needed for development, test, CI/CD, or staging. With no license configured,
-                Pro keeps running and logs its status instead of ever blocking your app.
+                No token is required for development, test, CI/CD, and staging, plus demos, education, or
+                qualifying open-source projects. Production use that creates private business value
+                requires a paid React on Rails Pro license.
               </span>
             </div>
             <div className={styles.actions}>
@@ -119,8 +120,8 @@ export default function ProPage(): ReactNode {
         <section className="container">
           <h2>What Pro adds</h2>
           <p className={styles.note}>
-            Every feature below ships in the public Pro gem. The license covers production use and
-            support — not access.
+            Every feature below ships in the public Pro gem. Trust-based commercial licensing covers
+            production use and support — not access to evaluate the package.
           </p>
           <div className={styles.cardGrid}>
             {proFeatures.map((feature) => (
@@ -179,19 +180,20 @@ export default function ProPage(): ReactNode {
             </article>
 
             <article className={styles.policyCard}>
-              <p className={styles.cardEyebrow}>Friendly license model</p>
-              <h2>Build now. License when you ship.</h2>
+              <p className={styles.cardEyebrow}>Trust-Based Commercial Licensing</p>
+              <h2>Free to learn. Paid when it creates private business value.</h2>
               <p>
-                Production deployments require a paid license, which includes support from the
-                ShakaCode maintainers. Visit{' '}
+                React on Rails Pro uses ShakaCode Trust-Based Commercial Licensing: free for
+                learning, demos, tutorials, education, and qualifying OSS; paid for production use
+                that creates private business value. Visit{' '}
                 <a href="https://pro.reactonrails.com/">Pro pricing and sign up</a> for current
                 options.
               </p>
               <p>
-                Budget-constrained? Email{' '}
-                <a href="mailto:justin@shakacode.com">justin@shakacode.com</a> — we grant free or
-                low-cost licenses in qualifying cases. Licenses from larger companies fund continued
-                React on Rails development.
+                The umbrella philosophy is separate from the legal terms: production use remains
+                governed by the React on Rails Pro EULA. Budget-constrained? Email{' '}
+                <a href="mailto:justin@shakacode.com">justin@shakacode.com</a> about free or
+                low-cost licenses in qualifying cases.
               </p>
             </article>
           </div>

--- a/scripts/prepare-docs.mjs
+++ b/scripts/prepare-docs.mjs
@@ -751,7 +751,7 @@ export function docsHomeMarkdown(sourceMarkdown, { hasArchive }) {
 - Production use remains governed by the React on Rails Pro EULA. See [Pro pricing and sign up](https://pro.reactonrails.com/) for current options. If your organization is budget-constrained, [contact us](mailto:justin@shakacode.com) about free or low-cost licenses.
 `;
   const legacyLicensingSectionPattern =
-    /## (?:Friendly evaluation policy|Friendly License Model|ShakaCode Trust-Based Commercial Licensing)\n\n[\s\S]*?(?=\n## |$)/;
+    /## (?:Friendly evaluation policy|Friendly License Model|ShakaCode Trust-Based Commercial Licensing)[^\n]*\n+[\s\S]*?(?=\n## |$)/;
 
   let updated = sourceMarkdown
     .trim()

--- a/scripts/prepare-docs.mjs
+++ b/scripts/prepare-docs.mjs
@@ -467,8 +467,25 @@ export async function injectProTrustBasedLicensingNotice(docsRoot) {
   }
 
   const notice = `> **ShakaCode Trust-Based Commercial Licensing**\n> Free to learn, evaluate, demo, and use for qualifying open-source projects. Paid when React on Rails Pro creates private business value in production. No token is required for development, test, CI/CD, and staging; Pro logs license status instead of blocking evaluation. Product-specific legal terms still apply: production use is governed by the React on Rails Pro EULA. See [Pro pricing and sign up](https://pro.reactonrails.com/).\n\n`;
+  const licensingSection = `## ShakaCode Trust-Based Commercial Licensing
+
+Free to learn, evaluate, demo, and use for qualifying open-source projects. Paid when React on Rails Pro creates private business value in production. No token is required for development, test, CI/CD, and staging; Pro logs license status instead of blocking evaluation.
+
+Product-specific legal terms still apply: production use is governed by the React on Rails Pro EULA. See [Pro pricing and sign up](https://pro.reactonrails.com/) for current options. If your organization is budget-constrained, email [justin@shakacode.com](mailto:justin@shakacode.com) about free or low-cost licenses in qualifying cases.
+`;
+  const licensingSectionPattern =
+    /(^|\n)## ShakaCode Trust-Based Commercial Licensing\n\n[\s\S]*?(?=\n## |\n*$)/;
   const legacyNoticePattern = /^> \*\*Friendly license model\*\*\n(?:>.*(?:\n|$))+\n?/gim;
   let hasTrustBasedNotice = /ShakaCode Trust-Based Commercial Licensing/i.test(updated);
+
+  if (licensingSectionPattern.test(updated)) {
+    updated = updated.replace(
+      licensingSectionPattern,
+      (_matchedSection, leadingNewline) => `${leadingNewline}${licensingSection}\n`
+    );
+    hasTrustBasedNotice = true;
+  }
+
   updated = updated.replace(legacyNoticePattern, () => {
     if (hasTrustBasedNotice) {
       return "";

--- a/scripts/prepare-docs.mjs
+++ b/scripts/prepare-docs.mjs
@@ -446,7 +446,7 @@ export async function rewriteFlattenedOssLinks(docsRoot) {
   });
 }
 
-export async function injectProFriendlyNotice(docsRoot) {
+export async function injectProTrustBasedLicensingNotice(docsRoot) {
   const proIntroPath = path.join(docsRoot, "pro", "react-on-rails-pro.md");
   if (!(await exists(proIntroPath))) {
     return;
@@ -466,8 +466,11 @@ export async function injectProFriendlyNotice(docsRoot) {
     }
   }
 
-  if (!/Friendly license model/i.test(updated)) {
-    const notice = `> **Friendly license model**\n> Try React on Rails Pro freely in development, test, CI/CD, and staging. No token is required to evaluate. If no license is configured, Pro keeps running in unlicensed mode and logs license status instead of blocking your app. Production deployments require a paid license; see [Pro pricing and sign up](https://pro.reactonrails.com/).\n\n`;
+  const notice = `> **ShakaCode Trust-Based Commercial Licensing**\n> Free to learn, evaluate, demo, and use for qualifying open-source projects. Paid when React on Rails Pro creates private business value in production. No token is required for development, test, CI/CD, and staging; Pro logs license status instead of blocking evaluation. Product-specific legal terms still apply: production use is governed by the React on Rails Pro EULA. See [Pro pricing and sign up](https://pro.reactonrails.com/).\n\n`;
+  const legacyNoticePattern = /^> \*\*Friendly license model\*\*\n> .+\n\n/m;
+  if (legacyNoticePattern.test(updated)) {
+    updated = updated.replace(legacyNoticePattern, notice);
+  } else if (!/ShakaCode Trust-Based Commercial Licensing/i.test(updated)) {
     updated = updated.replace(/^# React on Rails Pro\s*\n+/m, `# React on Rails Pro\n\n${notice}`);
   }
 
@@ -715,10 +718,12 @@ function injectPackageReferences(markdown) {
 
 export function docsHomeMarkdown(sourceMarkdown, { hasArchive }) {
   const archiveBlock = hasArchive ? "- [Historical Reference](./archive/README.md)\n" : "";
-  const friendlyLicenseSection = `## Friendly License Model
+  const licensingSection = `## ShakaCode Trust-Based Commercial Licensing
 
-- Try React on Rails Pro freely in development, test, CI/CD, and staging. No token is required to evaluate.
-- Production deployments require a paid license. See [Pro pricing and sign up](https://pro.reactonrails.com/) for current options. If your organization is budget-constrained, [contact us](mailto:justin@shakacode.com) about free or low-cost licenses.
+- Free to learn, evaluate, demo, and use for qualifying open-source projects.
+- Paid when React on Rails Pro creates private business value in production.
+- No token is required for development, test, CI/CD, and staging; Pro logs license status instead of blocking evaluation.
+- Production use remains governed by the React on Rails Pro EULA. See [Pro pricing and sign up](https://pro.reactonrails.com/) for current options. If your organization is budget-constrained, [contact us](mailto:justin@shakacode.com) about free or low-cost licenses.
 `;
 
   const updated = injectPackageReferences(sourceMarkdown
@@ -726,7 +731,7 @@ export function docsHomeMarkdown(sourceMarkdown, { hasArchive }) {
     .replaceAll("(./oss/", "(./")
     .replace("](https://reactonrails.com/examples)", "](/examples)")
     .replace(/\n- \[Documentation website\]\(https:\/\/reactonrails\.com\/docs\/\)\s*/g, "\n")
-    .replace(/## Friendly evaluation policy\n\n[\s\S]*?(?=\n## )/, `${friendlyLicenseSection}\n`)
+    .replace(/## (?:Friendly evaluation policy|Friendly License Model|ShakaCode Trust-Based Commercial Licensing)\n\n[\s\S]*?(?=\n## )/, `${licensingSection}\n`)
     .replace("## Need more help?\n\n", `## Need more help?\n\n${archiveBlock}`));
 
   return `---\ncustom_edit_url: null\n---\n\n${updated}\n`;
@@ -902,7 +907,7 @@ async function prepareDocusaurus() {
   if (layout === "split") {
     await rewriteFlattenedOssLinks(docsRoot);
   }
-  await injectProFriendlyNotice(docsRoot);
+  await injectProTrustBasedLicensingNotice(docsRoot);
   await fixKnownDocsIssues(docsRoot);
   await normalizeCodeFences(docsRoot);
   const hasArchive = await archiveLegacyDocs(docsRoot);

--- a/scripts/prepare-docs.mjs
+++ b/scripts/prepare-docs.mjs
@@ -467,10 +467,18 @@ export async function injectProTrustBasedLicensingNotice(docsRoot) {
   }
 
   const notice = `> **ShakaCode Trust-Based Commercial Licensing**\n> Free to learn, evaluate, demo, and use for qualifying open-source projects. Paid when React on Rails Pro creates private business value in production. No token is required for development, test, CI/CD, and staging; Pro logs license status instead of blocking evaluation. Product-specific legal terms still apply: production use is governed by the React on Rails Pro EULA. See [Pro pricing and sign up](https://pro.reactonrails.com/).\n\n`;
-  const legacyNoticePattern = /^> \*\*Friendly license model\*\*\n> .+\n\n/m;
-  if (legacyNoticePattern.test(updated)) {
-    updated = updated.replace(legacyNoticePattern, notice);
-  } else if (!/ShakaCode Trust-Based Commercial Licensing/i.test(updated)) {
+  const legacyNoticePattern = /^> \*\*Friendly license model\*\*\n(?:>.*(?:\n|$))+\n?/gim;
+  let hasTrustBasedNotice = /ShakaCode Trust-Based Commercial Licensing/i.test(updated);
+  updated = updated.replace(legacyNoticePattern, () => {
+    if (hasTrustBasedNotice) {
+      return "";
+    }
+
+    hasTrustBasedNotice = true;
+    return notice;
+  });
+
+  if (!hasTrustBasedNotice) {
     updated = updated.replace(/^# React on Rails Pro\s*\n+/m, `# React on Rails Pro\n\n${notice}`);
   }
 
@@ -725,14 +733,29 @@ export function docsHomeMarkdown(sourceMarkdown, { hasArchive }) {
 - No token is required for development, test, CI/CD, and staging; Pro logs license status instead of blocking evaluation.
 - Production use remains governed by the React on Rails Pro EULA. See [Pro pricing and sign up](https://pro.reactonrails.com/) for current options. If your organization is budget-constrained, [contact us](mailto:justin@shakacode.com) about free or low-cost licenses.
 `;
+  const legacyLicensingSectionPattern =
+    /## (?:Friendly evaluation policy|Friendly License Model|ShakaCode Trust-Based Commercial Licensing)\n\n[\s\S]*?(?=\n## |$)/;
 
-  const updated = injectPackageReferences(sourceMarkdown
+  let updated = sourceMarkdown
     .trim()
     .replaceAll("(./oss/", "(./")
     .replace("](https://reactonrails.com/examples)", "](/examples)")
-    .replace(/\n- \[Documentation website\]\(https:\/\/reactonrails\.com\/docs\/\)\s*/g, "\n")
-    .replace(/## (?:Friendly evaluation policy|Friendly License Model|ShakaCode Trust-Based Commercial Licensing)\n\n[\s\S]*?(?=\n## )/, `${licensingSection}\n`)
-    .replace("## Need more help?\n\n", `## Need more help?\n\n${archiveBlock}`));
+    .replace(/\n- \[Documentation website\]\(https:\/\/reactonrails\.com\/docs\/\)\s*/g, "\n");
+
+  if (legacyLicensingSectionPattern.test(updated)) {
+    updated = updated.replace(legacyLicensingSectionPattern, `${licensingSection}\n`);
+  } else if (!/## ShakaCode Trust-Based Commercial Licensing/i.test(updated)) {
+    const helpHeadingPattern = /^## Need more help\?\s*(?:\n|$)/m;
+    if (helpHeadingPattern.test(updated)) {
+      updated = updated.replace(helpHeadingPattern, `${licensingSection}\n## Need more help?\n\n`);
+    } else {
+      updated = `${updated.trimEnd()}\n\n${licensingSection}`;
+    }
+  }
+
+  updated = injectPackageReferences(
+    updated.replace(/^## Need more help\?\s*(?:\n|$)/m, `## Need more help?\n\n${archiveBlock}`)
+  );
 
   return `---\ncustom_edit_url: null\n---\n\n${updated}\n`;
 }

--- a/scripts/prepare-docs.test.mjs
+++ b/scripts/prepare-docs.test.mjs
@@ -102,6 +102,35 @@ Existing Pro overview.
   });
 });
 
+test("prepare docs normalizes existing Pro trust-based licensing section", async () => {
+  await withTempDir(async (docsRoot) => {
+    const proIntroPath = path.join(docsRoot, "pro", "react-on-rails-pro.md");
+    await fs.mkdir(path.dirname(proIntroPath), { recursive: true });
+    await fs.writeFile(
+      proIntroPath,
+      `# React on Rails Pro
+
+## ShakaCode Trust-Based Commercial Licensing
+
+Trust-based means ShakaCode keeps evaluation low-friction instead of forcing runtime lockouts in non-production environments.
+It relies on professional teams to purchase a license before production deployment.
+
+## Explore the Dummy App
+`,
+      "utf8"
+    );
+
+    await injectProTrustBasedLicensingNotice(docsRoot);
+
+    const updated = await fs.readFile(proIntroPath, "utf8");
+    assert.match(updated, /ShakaCode Trust-Based Commercial Licensing/);
+    assert.match(updated, /private business value in production/);
+    assert.match(updated, /React on Rails Pro EULA/);
+    assert.match(updated, /## Explore the Dummy App/);
+    assert.doesNotMatch(updated, /professional teams to purchase/);
+  });
+});
+
 test("docs homepage uses trust-based commercial licensing copy", () => {
   const sourceMarkdown = `# React on Rails
 

--- a/scripts/prepare-docs.test.mjs
+++ b/scripts/prepare-docs.test.mjs
@@ -75,6 +75,33 @@ test("prepare docs injects trust-based commercial licensing notice", async () =>
   });
 });
 
+test("prepare docs replaces multi-line legacy Pro licensing notice", async () => {
+  await withTempDir(async (docsRoot) => {
+    const proIntroPath = path.join(docsRoot, "pro", "react-on-rails-pro.md");
+    await fs.mkdir(path.dirname(proIntroPath), { recursive: true });
+    await fs.writeFile(
+      proIntroPath,
+      `# React on Rails Pro
+
+> **Friendly license model**
+> You can try React on Rails Pro in development without a license.
+> Teams should contact us before production.
+
+Existing Pro overview.
+`,
+      "utf8"
+    );
+
+    await injectProTrustBasedLicensingNotice(docsRoot);
+
+    const updated = await fs.readFile(proIntroPath, "utf8");
+    assert.match(updated, /ShakaCode Trust-Based Commercial Licensing/);
+    assert.match(updated, /private business value in production/);
+    assert.doesNotMatch(updated, /Friendly license model/);
+    assert.doesNotMatch(updated, /Teams should contact us before production/);
+  });
+});
+
 test("docs homepage uses trust-based commercial licensing copy", () => {
   const sourceMarkdown = `# React on Rails
 
@@ -97,6 +124,21 @@ test("docs homepage uses trust-based commercial licensing copy", () => {
   assert.doesNotMatch(updated, /Friendly License Model/);
   assert.doesNotMatch(updated, /Friendly evaluation policy/);
   assert.doesNotMatch(updated, /Honest License/);
+});
+
+test("docs homepage inserts trust-based commercial licensing copy when no legacy section exists", () => {
+  const sourceMarkdown = `# React on Rails
+
+## Need more help?
+`;
+
+  const updated = docsHomeMarkdown(sourceMarkdown, { hasArchive: false });
+
+  assert.match(updated, /## ShakaCode Trust-Based Commercial Licensing/);
+  assert.match(updated, /## Need more help\?/);
+  assert.match(updated, /private business value in production/);
+  assert.match(updated, /React on Rails Pro EULA/);
+  assert(updated.indexOf("## ShakaCode Trust-Based Commercial Licensing") < updated.indexOf("## Need more help?"));
 });
 
 test("docs homepage renders a package table with linked names and live version badges", () => {

--- a/scripts/prepare-docs.test.mjs
+++ b/scripts/prepare-docs.test.mjs
@@ -9,7 +9,7 @@ import {
   copySyncedStaticFiles,
   docsHomeMarkdown,
   fixProNodeRendererMdx,
-  injectProFriendlyNotice,
+  injectProTrustBasedLicensingNotice,
   rewriteFlattenedOssLinks,
   rewriteProLinks,
   siteSidebarSource,
@@ -49,7 +49,7 @@ test("prepare docs keeps external Pro pricing links", async () => {
   });
 });
 
-test("prepare docs injects current friendly license model notice", async () => {
+test("prepare docs injects trust-based commercial licensing notice", async () => {
   await withTempDir(async (docsRoot) => {
     const proIntroPath = path.join(docsRoot, "pro", "react-on-rails-pro.md");
     await fs.mkdir(path.dirname(proIntroPath), { recursive: true });
@@ -59,18 +59,23 @@ test("prepare docs injects current friendly license model notice", async () => {
       "utf8"
     );
 
-    await injectProFriendlyNotice(docsRoot);
+    await injectProTrustBasedLicensingNotice(docsRoot);
 
     const updated = await fs.readFile(proIntroPath, "utf8");
     assert.match(updated, /slug: \/pro/);
-    assert.match(updated, /Friendly license model/);
+    assert.match(updated, /ShakaCode Trust-Based Commercial Licensing/);
+    assert.match(updated, /Free to learn, evaluate, demo/);
+    assert.match(updated, /private business value in production/);
+    assert.match(updated, /React on Rails Pro EULA/);
     assert.match(updated, /development, test, CI\/CD, and staging/);
     assert.match(updated, /https:\/\/pro\.reactonrails\.com\//);
+    assert.doesNotMatch(updated, /Friendly license model/);
     assert.doesNotMatch(updated, /Friendly evaluation policy/);
+    assert.doesNotMatch(updated, /Honest License/);
   });
 });
 
-test("docs homepage uses current friendly license model copy", () => {
+test("docs homepage uses trust-based commercial licensing copy", () => {
   const sourceMarkdown = `# React on Rails
 
 ## Friendly evaluation policy
@@ -83,10 +88,15 @@ test("docs homepage uses current friendly license model copy", () => {
 
   const updated = docsHomeMarkdown(sourceMarkdown, { hasArchive: false });
 
-  assert.match(updated, /## Friendly License Model/);
+  assert.match(updated, /## ShakaCode Trust-Based Commercial Licensing/);
+  assert.match(updated, /Free to learn, evaluate, demo/);
+  assert.match(updated, /private business value in production/);
+  assert.match(updated, /React on Rails Pro EULA/);
   assert.match(updated, /development, test, CI\/CD, and staging/);
   assert.match(updated, /https:\/\/pro\.reactonrails\.com\//);
+  assert.doesNotMatch(updated, /Friendly License Model/);
   assert.doesNotMatch(updated, /Friendly evaluation policy/);
+  assert.doesNotMatch(updated, /Honest License/);
 });
 
 test("docs homepage renders a package table with linked names and live version badges", () => {

--- a/scripts/prepare-docs.test.mjs
+++ b/scripts/prepare-docs.test.mjs
@@ -170,6 +170,24 @@ test("docs homepage inserts trust-based commercial licensing copy when no legacy
   assert(updated.indexOf("## ShakaCode Trust-Based Commercial Licensing") < updated.indexOf("## Need more help?"));
 });
 
+test("docs homepage replaces compact legacy licensing section headings", () => {
+  const sourceMarkdown = `# React on Rails
+
+## Friendly evaluation policy - no runtime lockouts
+You can try React on Rails Pro without a license while evaluating.
+
+## Need more help?
+`;
+
+  const updated = docsHomeMarkdown(sourceMarkdown, { hasArchive: false });
+
+  assert.match(updated, /## ShakaCode Trust-Based Commercial Licensing/);
+  assert.match(updated, /private business value in production/);
+  assert.match(updated, /React on Rails Pro EULA/);
+  assert.doesNotMatch(updated, /Friendly evaluation policy/);
+  assert.doesNotMatch(updated, /without a license while evaluating/);
+});
+
 test("docs homepage renders a package table with linked names and live version badges", () => {
   const sourceMarkdown = `# React on Rails
 


### PR DESCRIPTION
## Summary
- Update the React on Rails Pro page to use ShakaCode Trust-Based Commercial Licensing wording.
- Update generated docs injection copy from the old friendly-license wording to the trust-based commercial licensing term.
- Add tests that assert the new terminology, private-business-value positioning, and React on Rails Pro EULA distinction.

## Why
Issue #138 asks reactonrails.com to use ShakaCode Trust-Based Commercial Licensing consistently and avoid public Honest License branding. This keeps evaluation/learning language clear while preserving the product-specific legal terms for React on Rails Pro.

Closes #138

## Test plan
- `npm run sync:docs`
- `npm run prepare:docs`
- `npm run install:site`
- `.agents/bin/validate`
- `node --test scripts/prepare-docs.test.mjs`

## Codex Decision Log
- **Non-blocking:** `npm run prepare:docs` regenerated `prototypes/docusaurus/sidebars.ts` from upstream.
  - **Decision:** Do not commit that generated sidebar drift in this PR.
  - **Why:** #138 is scoped to site-owned licensing copy and prepare-docs injection/tests; sidebar drift is unrelated generated navigation churn.
  - **Review later:** Handle generated sidebar refresh in the navigation/migration-guide lane or an upstream docs sync PR if needed.